### PR TITLE
feat: add local synonym generation for alert descriptors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
           enable-cache: true
       - name: Install dependencies
         run: uv pip install --system -r Backend/requirements.txt -r Backend/requirements-dev.txt
+      - name: Install NLTK data
+        run: python -m nltk.downloader -q wordnet omw-1.4
       - name: Run unit tests
         run: |
           cd Backend
@@ -113,6 +115,8 @@ jobs:
           enable-cache: true
       - name: Install dependencies
         run: uv pip install --system -r Backend/requirements.txt -r Backend/requirements-dev.txt
+      - name: Install NLTK data
+        run: python -m nltk.downloader -q wordnet omw-1.4
       - name: Run migrations
         run: |
           cd Backend
@@ -302,6 +306,7 @@ jobs:
       - name: Install test deps and generate coverage
         run: |
           uv pip install --system -r Backend/requirements.txt -r Backend/requirements-dev.txt
+          python -m nltk.downloader -q wordnet omw-1.4
           cd Backend && pytest tests/unit tests/functional -m "unit or functional" \
             --cov=app --cov-report=xml:../coverage.xml --tb=short || true
 

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ blob-report/
 
 # OS
 Thumbs.db
+
+# AI
+.codex

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ env/
 .venv/
 .env
 
+# Local model assets
+.models/
+
 # Testing / Coverage
 .coverage
 htmlcov/

--- a/Backend/Dockerfile
+++ b/Backend/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /app
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
+ENV NLTK_DATA=/usr/local/share/nltk_data
+RUN python -m nltk.downloader -d "$NLTK_DATA" wordnet omw-1.4
 
 COPY . .
 

--- a/Backend/app/core/synonyms.py
+++ b/Backend/app/core/synonyms.py
@@ -11,6 +11,10 @@ DEFAULT_LANGUAGE = "spa"
 MIN_SYNONYM_LIMIT = 3
 MAX_SYNONYM_LIMIT = 10
 DEFAULT_SYNONYM_LIMIT = MAX_SYNONYM_LIMIT
+FALLBACK_SYNONYMS: dict[str, list[str]] = {
+    "ia": ["inteligencia artificial", "aprendizaje automático", "ai"],
+    "inteligencia artificial": ["ia", "aprendizaje automático", "ai"],
+}
 
 
 class SynonymDataNotAvailableError(RuntimeError):
@@ -41,18 +45,35 @@ def generate_synonyms(term: str, limit: int = DEFAULT_SYNONYM_LIMIT, language: s
     synonyms: list[str] = []
     seen: set[str] = set()
 
-    for lookup_term in lookup_terms:
-        for synset in _synsets_for(lookup_term, language):
-            for lemma in synset.lemma_names(lang=language):
-                synonym = normalize_text(lemma)
-                if not synonym or synonym in excluded_terms or synonym in seen:
-                    continue
+    _append_wordnet_synonyms(
+        lookup_terms=lookup_terms,
+        language=language,
+        excluded_terms=excluded_terms,
+        seen=seen,
+        synonyms=synonyms,
+        max_results=max_results,
+    )
 
-                synonyms.append(synonym)
-                seen.add(synonym)
+    # Para frases compuestas sin entrada directa en WordNet, intentamos con cada token.
+    if len(synonyms) < max_results and " " in normalized_term:
+        phrase_tokens = [token for token in normalized_term.split(" ") if token]
+        _append_wordnet_synonyms(
+            lookup_terms=phrase_tokens,
+            language=language,
+            excluded_terms=excluded_terms,
+            seen=seen,
+            synonyms=synonyms,
+            max_results=max_results,
+        )
 
-                if len(synonyms) >= max_results:
-                    return synonyms
+    if len(synonyms) < max_results:
+        _append_fallback_synonyms(
+            term=normalized_term,
+            excluded_terms=excluded_terms,
+            seen=seen,
+            synonyms=synonyms,
+            max_results=max_results,
+        )
 
     return synonyms
 
@@ -84,3 +105,62 @@ def _lookup_terms(term: str) -> list[str]:
             seen.add(candidate)
 
     return deduped
+
+
+def _append_wordnet_synonyms(
+    lookup_terms: list[str],
+    language: str,
+    excluded_terms: set[str],
+    seen: set[str],
+    synonyms: list[str],
+    max_results: int,
+) -> None:
+    for lookup_term in lookup_terms:
+        for synset in _synsets_for(lookup_term, language):
+            for lemma in synset.lemma_names(lang=language):
+                _append_synonym_candidate(
+                    candidate=lemma,
+                    excluded_terms=excluded_terms,
+                    seen=seen,
+                    synonyms=synonyms,
+                    max_results=max_results,
+                )
+                if len(synonyms) >= max_results:
+                    return
+
+
+def _append_fallback_synonyms(
+    term: str,
+    excluded_terms: set[str],
+    seen: set[str],
+    synonyms: list[str],
+    max_results: int,
+) -> None:
+    for candidate in FALLBACK_SYNONYMS.get(term, []):
+        _append_synonym_candidate(
+            candidate=candidate,
+            excluded_terms=excluded_terms,
+            seen=seen,
+            synonyms=synonyms,
+            max_results=max_results,
+        )
+        if len(synonyms) >= max_results:
+            return
+
+
+def _append_synonym_candidate(
+    candidate: str,
+    excluded_terms: set[str],
+    seen: set[str],
+    synonyms: list[str],
+    max_results: int,
+) -> None:
+    synonym = normalize_text(candidate)
+    if not synonym or synonym in excluded_terms or synonym in seen:
+        return
+
+    synonyms.append(synonym)
+    seen.add(synonym)
+
+    if len(synonyms) >= max_results:
+        return

--- a/Backend/app/core/synonyms.py
+++ b/Backend/app/core/synonyms.py
@@ -1,10 +1,14 @@
-"""Generación local de sinónimos usando WordNet multilingüe de NLTK."""
+"""Generación local de sinónimos usando WordNet y sugerencias fastText opcionales."""
 
 from __future__ import annotations
 
+import importlib
+import os
 import re
 import threading
 import unicodedata
+from pathlib import Path
+from typing import Any
 
 from nltk.corpus import wordnet
 
@@ -12,19 +16,32 @@ DEFAULT_LANGUAGE = "spa"
 MIN_SYNONYM_LIMIT = 3
 MAX_SYNONYM_LIMIT = 10
 DEFAULT_SYNONYM_LIMIT = MAX_SYNONYM_LIMIT
+FASTTEXT_MODEL_PATH_ENV = "NEWSRADAR_FASTTEXT_MODEL_PATH"
+FASTTEXT_CANDIDATE_MULTIPLIER = 4
+FASTTEXT_MIN_CANDIDATES = 20
 FALLBACK_SYNONYMS: dict[str, list[str]] = {
     "ia": ["inteligencia artificial", "aprendizaje automático", "ai"],
     "inteligencia artificial": ["ia", "aprendizaje automático", "ai"],
 }
 WARMUP_PROBE_TERM = "casa"
+FASTTEXT_WARMUP_PROBE_TERM = "tecnologia"
 WARMUP_STATUS_COLD = "cold"
 WARMUP_STATUS_WARMING = "warming"
 WARMUP_STATUS_WARMED = "warmed"
 WARMUP_STATUS_FAILED = "failed"
+FASTTEXT_STATUS_COLD = "cold"
+FASTTEXT_STATUS_LOADING = "loading"
+FASTTEXT_STATUS_LOADED = "loaded"
+FASTTEXT_STATUS_UNAVAILABLE = "unavailable"
 
 _warmup_lock = threading.Lock()
 _warmup_status = WARMUP_STATUS_COLD
 _warmup_error: str | None = None
+_fasttext_lock = threading.Lock()
+_fasttext_model: Any | None = None
+_fasttext_status = FASTTEXT_STATUS_COLD
+_fasttext_error: str | None = None
+_fasttext_notice_logged = False
 
 
 class SynonymDataNotAvailableError(RuntimeError):
@@ -47,6 +64,7 @@ def warmup_synonym_resources(language: str = DEFAULT_LANGUAGE) -> tuple[str, str
 
     try:
         _synsets_for(WARMUP_PROBE_TERM, language)
+        _warmup_fasttext_resources()
     except SynonymDataNotAvailableError as exc:
         with _warmup_lock:
             _warmup_status = WARMUP_STATUS_FAILED
@@ -68,6 +86,20 @@ def _reset_warmup_state_for_tests() -> None:
     with _warmup_lock:
         _warmup_status = WARMUP_STATUS_COLD
         _warmup_error = None
+    _reset_fasttext_state_for_tests()
+
+
+def _reset_fasttext_state_for_tests() -> None:
+    """Reinicia el estado de fastText para pruebas unitarias."""
+    global _fasttext_error
+    global _fasttext_model
+    global _fasttext_notice_logged
+    global _fasttext_status
+    with _fasttext_lock:
+        _fasttext_model = None
+        _fasttext_status = FASTTEXT_STATUS_COLD
+        _fasttext_error = None
+        _fasttext_notice_logged = False
 
 
 def normalize_text(value: str) -> str:
@@ -83,7 +115,7 @@ def normalize_limit(limit: int) -> int:
 
 
 def generate_synonyms(term: str, limit: int = DEFAULT_SYNONYM_LIMIT, language: str = DEFAULT_LANGUAGE) -> list[str]:
-    """Devuelve sinónimos limpios y deduplicados para un término."""
+    """Devuelve sinónimos y términos relacionados limpios y deduplicados."""
     normalized_term = normalize_text(term)
     if not normalized_term:
         return []
@@ -118,6 +150,15 @@ def generate_synonyms(term: str, limit: int = DEFAULT_SYNONYM_LIMIT, language: s
     if len(synonyms) < max_results:
         _append_fallback_synonyms(
             term=normalized_term,
+            excluded_terms=excluded_terms,
+            seen=seen,
+            synonyms=synonyms,
+            max_results=max_results,
+        )
+
+    if len(synonyms) < max_results:
+        _append_fasttext_related_terms(
+            lookup_terms=lookup_terms,
             excluded_terms=excluded_terms,
             seen=seen,
             synonyms=synonyms,
@@ -197,15 +238,129 @@ def _append_fallback_synonyms(
             return
 
 
+def _append_fasttext_related_terms(
+    lookup_terms: list[str],
+    excluded_terms: set[str],
+    seen: set[str],
+    synonyms: list[str],
+    max_results: int,
+) -> None:
+    """Añade términos relacionados por vectores fastText; no son sinónimos estrictos."""
+    remaining = max_results - len(synonyms)
+    if remaining <= 0:
+        return
+
+    model = _get_fasttext_model()
+    if model is None:
+        return
+
+    candidates_to_fetch = max(FASTTEXT_MIN_CANDIDATES, remaining * FASTTEXT_CANDIDATE_MULTIPLIER)
+    for lookup_term in lookup_terms:
+        for candidate in _fasttext_candidates_for(model, lookup_term, candidates_to_fetch):
+            _append_synonym_candidate(
+                candidate=candidate,
+                excluded_terms=excluded_terms,
+                seen=seen,
+                synonyms=synonyms,
+                max_results=max_results,
+                strict_token=True,
+            )
+            if len(synonyms) >= max_results:
+                return
+
+
+def _fasttext_candidates_for(model: Any, term: str, limit: int) -> list[str]:
+    try:
+        neighbors = model.get_nearest_neighbors(term.replace(" ", "_"), k=limit)
+    except Exception as exc:
+        _log_fasttext_notice(f"fallback fastText no disponible para '{term}': {exc}")
+        return []
+
+    return [candidate for _score, candidate in neighbors]
+
+
+def _warmup_fasttext_resources() -> None:
+    model = _get_fasttext_model()
+    if model is None:
+        return
+    _fasttext_candidates_for(model, FASTTEXT_WARMUP_PROBE_TERM, 1)
+
+
+def _get_fasttext_model() -> Any | None:
+    global _fasttext_error
+    global _fasttext_model
+    global _fasttext_status
+
+    with _fasttext_lock:
+        if _fasttext_status == FASTTEXT_STATUS_LOADED:
+            return _fasttext_model
+        if _fasttext_status == FASTTEXT_STATUS_UNAVAILABLE:
+            return None
+        if _fasttext_status == FASTTEXT_STATUS_LOADING:
+            return None
+        _fasttext_status = FASTTEXT_STATUS_LOADING
+
+    model_path = os.getenv(FASTTEXT_MODEL_PATH_ENV, "").strip()
+    if not model_path:
+        _mark_fasttext_unavailable(f"{FASTTEXT_MODEL_PATH_ENV} no configurado")
+        return None
+
+    resolved_model_path = Path(model_path)
+    if not resolved_model_path.is_file():
+        _mark_fasttext_unavailable(f"modelo no encontrado en {resolved_model_path}")
+        return None
+
+    try:
+        fasttext = importlib.import_module("fasttext")
+        loaded_model = fasttext.load_model(str(resolved_model_path))
+    except ImportError as exc:
+        _mark_fasttext_unavailable("paquete fasttext no instalado", exc)
+        return None
+    except Exception as exc:
+        _mark_fasttext_unavailable(f"no se pudo cargar {resolved_model_path}", exc)
+        return None
+
+    with _fasttext_lock:
+        _fasttext_model = loaded_model
+        _fasttext_status = FASTTEXT_STATUS_LOADED
+        _fasttext_error = None
+        return _fasttext_model
+
+
+def _mark_fasttext_unavailable(reason: str, exc: Exception | None = None) -> None:
+    global _fasttext_error
+    global _fasttext_status
+
+    detail = f"{reason}: {exc}" if exc else reason
+    with _fasttext_lock:
+        _fasttext_status = FASTTEXT_STATUS_UNAVAILABLE
+        _fasttext_error = detail
+    _log_fasttext_notice(f"fallback fastText deshabilitado: {detail}")
+
+
+def _log_fasttext_notice(message: str) -> None:
+    global _fasttext_notice_logged
+
+    with _fasttext_lock:
+        if _fasttext_notice_logged:
+            return
+        _fasttext_notice_logged = True
+
+    print(f"[SYNONYMS] {message}")
+
+
 def _append_synonym_candidate(
     candidate: str,
     excluded_terms: set[str],
     seen: set[str],
     synonyms: list[str],
     max_results: int,
+    strict_token: bool = False,
 ) -> None:
     synonym = normalize_text(candidate)
     if not synonym or synonym in excluded_terms or synonym in seen:
+        return
+    if strict_token and not _is_valid_fasttext_candidate(synonym):
         return
 
     synonyms.append(synonym)
@@ -213,3 +368,15 @@ def _append_synonym_candidate(
 
     if len(synonyms) >= max_results:
         return
+
+
+def _is_valid_fasttext_candidate(candidate: str) -> bool:
+    if len(candidate) < 3:
+        return False
+    if candidate.isnumeric():
+        return False
+    if "://" in candidate or candidate.startswith("www.") or "@" in candidate:
+        return False
+    if not re.fullmatch(r"[a-záéíóúüñ0-9]+", candidate):
+        return False
+    return any(char.isalpha() for char in candidate)

--- a/Backend/app/core/synonyms.py
+++ b/Backend/app/core/synonyms.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import threading
 import unicodedata
 
 from nltk.corpus import wordnet
@@ -15,10 +16,58 @@ FALLBACK_SYNONYMS: dict[str, list[str]] = {
     "ia": ["inteligencia artificial", "aprendizaje automático", "ai"],
     "inteligencia artificial": ["ia", "aprendizaje automático", "ai"],
 }
+WARMUP_PROBE_TERM = "casa"
+WARMUP_STATUS_COLD = "cold"
+WARMUP_STATUS_WARMING = "warming"
+WARMUP_STATUS_WARMED = "warmed"
+WARMUP_STATUS_FAILED = "failed"
+
+_warmup_lock = threading.Lock()
+_warmup_status = WARMUP_STATUS_COLD
+_warmup_error: str | None = None
 
 
 class SynonymDataNotAvailableError(RuntimeError):
     """Indica que los corpus locales de NLTK no están instalados."""
+
+
+def warmup_synonym_resources(language: str = DEFAULT_LANGUAGE) -> tuple[str, str | None]:
+    """Precarga recursos de sinónimos para evitar latencia en la primera consulta."""
+    global _warmup_error
+    global _warmup_status
+
+    with _warmup_lock:
+        if _warmup_status == WARMUP_STATUS_WARMED:
+            return "already_warmed", None
+        if _warmup_status == WARMUP_STATUS_FAILED:
+            return "failed", _warmup_error
+        if _warmup_status == WARMUP_STATUS_WARMING:
+            return "warming", None
+        _warmup_status = WARMUP_STATUS_WARMING
+
+    try:
+        _synsets_for(WARMUP_PROBE_TERM, language)
+    except SynonymDataNotAvailableError as exc:
+        with _warmup_lock:
+            _warmup_status = WARMUP_STATUS_FAILED
+            _warmup_error = str(exc)
+        print(f"[SYNONYMS] Warmup fallido: {exc}")
+        return "failed", _warmup_error
+
+    with _warmup_lock:
+        _warmup_status = WARMUP_STATUS_WARMED
+        _warmup_error = None
+
+    return "warmed", None
+
+
+def _reset_warmup_state_for_tests() -> None:
+    """Reinicia el estado de warmup para pruebas unitarias."""
+    global _warmup_error
+    global _warmup_status
+    with _warmup_lock:
+        _warmup_status = WARMUP_STATUS_COLD
+        _warmup_error = None
 
 
 def normalize_text(value: str) -> str:

--- a/Backend/app/core/synonyms.py
+++ b/Backend/app/core/synonyms.py
@@ -1,0 +1,86 @@
+"""Generación local de sinónimos usando WordNet multilingüe de NLTK."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from nltk.corpus import wordnet
+
+DEFAULT_LANGUAGE = "spa"
+MIN_SYNONYM_LIMIT = 3
+MAX_SYNONYM_LIMIT = 10
+DEFAULT_SYNONYM_LIMIT = MAX_SYNONYM_LIMIT
+
+
+class SynonymDataNotAvailableError(RuntimeError):
+    """Indica que los corpus locales de NLTK no están instalados."""
+
+
+def normalize_text(value: str) -> str:
+    """Normaliza espacios, guiones bajos y capitalización sin eliminar acentos."""
+    normalized = unicodedata.normalize("NFKC", value.replace("_", " "))
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+    return normalized.casefold()
+
+
+def normalize_limit(limit: int) -> int:
+    """Ajusta el límite al rango soportado por la aplicación."""
+    return max(MIN_SYNONYM_LIMIT, min(limit, MAX_SYNONYM_LIMIT))
+
+
+def generate_synonyms(term: str, limit: int = DEFAULT_SYNONYM_LIMIT, language: str = DEFAULT_LANGUAGE) -> list[str]:
+    """Devuelve sinónimos limpios y deduplicados para un término."""
+    normalized_term = normalize_text(term)
+    if not normalized_term:
+        return []
+
+    max_results = normalize_limit(limit)
+    lookup_terms = _lookup_terms(normalized_term)
+    excluded_terms = {normalize_text(lookup_term) for lookup_term in lookup_terms}
+    synonyms: list[str] = []
+    seen: set[str] = set()
+
+    for lookup_term in lookup_terms:
+        for synset in _synsets_for(lookup_term, language):
+            for lemma in synset.lemma_names(lang=language):
+                synonym = normalize_text(lemma)
+                if not synonym or synonym in excluded_terms or synonym in seen:
+                    continue
+
+                synonyms.append(synonym)
+                seen.add(synonym)
+
+                if len(synonyms) >= max_results:
+                    return synonyms
+
+    return synonyms
+
+
+def _synsets_for(term: str, language: str):
+    try:
+        return wordnet.synsets(term.replace(" ", "_"), lang=language)
+    except LookupError as exc:
+        raise SynonymDataNotAvailableError(
+            "Los corpus de NLTK 'wordnet' y 'omw-1.4' deben estar instalados para generar sinónimos."
+        ) from exc
+
+
+def _lookup_terms(term: str) -> list[str]:
+    candidates = [term]
+
+    if len(term) > 4 and term.endswith("ces"):
+        candidates.append(f"{term[:-3]}z")
+    if len(term) > 4 and term.endswith("es"):
+        candidates.append(term[:-2])
+    if len(term) > 3 and term.endswith("s"):
+        candidates.append(term[:-1])
+
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        if candidate not in seen:
+            deduped.append(candidate)
+            seen.add(candidate)
+
+    return deduped

--- a/Backend/app/main.py
+++ b/Backend/app/main.py
@@ -14,7 +14,7 @@ import feedparser
 import requests
 from dotenv import load_dotenv
 from elasticsearch import Elasticsearch
-from fastapi import Depends, FastAPI, HTTPException, Response, status
+from fastapi import Depends, FastAPI, HTTPException, Query, Response, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import JWTError, jwt
@@ -31,6 +31,14 @@ from app.core.security import (
     send_alert_email,
     send_verification_email,
     verify_password,
+)
+from app.core.synonyms import (
+    DEFAULT_LANGUAGE,
+    DEFAULT_SYNONYM_LIMIT,
+    MAX_SYNONYM_LIMIT,
+    MIN_SYNONYM_LIMIT,
+    SynonymDataNotAvailableError,
+    generate_synonyms,
 )
 from app.db.database import SessionLocal, get_db
 from app.models import models as db_models
@@ -340,6 +348,13 @@ class TokenResponse(BaseModel):
     token_type: str = "bearer"
 
 
+class SynonymResponse(BaseModel):
+    term: str
+    language: str = DEFAULT_LANGUAGE
+    limit: int
+    synonyms: list[str] = Field(default_factory=list)
+
+
 def ensure_role_ids_exist(role_ids: list[int], db: Session = Depends(get_db)) -> None:
     """Verifica en PostgreSQL que los IDs de roles proporcionados existen."""
     if not role_ids:
@@ -541,6 +556,21 @@ def create_seed_data() -> None:
 def health() -> dict:
     """Devuelve estado de salud básico del servicio."""
     return {"status": "ok", "timestamp": datetime.now(UTC).isoformat()}
+
+
+@app.get(f"{API_PREFIX}/alerts/synonyms", response_model=SynonymResponse, tags=["alerts"])
+async def get_alert_synonyms(
+    term: str = Query(..., min_length=1, max_length=120),
+    limit: int = Query(DEFAULT_SYNONYM_LIMIT, ge=MIN_SYNONYM_LIMIT, le=MAX_SYNONYM_LIMIT),
+    _: db_models.User = Depends(get_current_user),
+) -> SynonymResponse:
+    """Genera sinónimos locales en español para descriptores de alertas."""
+    try:
+        synonyms = generate_synonyms(term=term, limit=limit, language=DEFAULT_LANGUAGE)
+    except SynonymDataNotAvailableError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+    return SynonymResponse(term=term.strip(), language=DEFAULT_LANGUAGE, limit=limit, synonyms=synonyms)
 
 
 @app.post(f"{API_PREFIX}/auth/login", response_model=TokenResponse, tags=["auth"])

--- a/Backend/app/main.py
+++ b/Backend/app/main.py
@@ -39,6 +39,7 @@ from app.core.synonyms import (
     MIN_SYNONYM_LIMIT,
     SynonymDataNotAvailableError,
     generate_synonyms,
+    warmup_synonym_resources,
 )
 from app.db.database import SessionLocal, get_db
 from app.models import models as db_models
@@ -355,6 +356,11 @@ class SynonymResponse(BaseModel):
     synonyms: list[str] = Field(default_factory=list)
 
 
+class SynonymWarmupResponse(BaseModel):
+    status: str
+    detail: str | None = None
+
+
 def ensure_role_ids_exist(role_ids: list[int], db: Session = Depends(get_db)) -> None:
     """Verifica en PostgreSQL que los IDs de roles proporcionados existen."""
     if not role_ids:
@@ -571,6 +577,13 @@ async def get_alert_synonyms(
         raise HTTPException(status_code=503, detail=str(exc)) from exc
 
     return SynonymResponse(term=term.strip(), language=DEFAULT_LANGUAGE, limit=limit, synonyms=synonyms)
+
+
+@app.get(f"{API_PREFIX}/alerts/synonyms/warmup", response_model=SynonymWarmupResponse, tags=["alerts"])
+async def warmup_alert_synonyms(_: db_models.User = Depends(get_current_user)) -> SynonymWarmupResponse:
+    """Precarga recursos de sinónimos para evitar latencia en la primera búsqueda."""
+    status, detail = warmup_synonym_resources(language=DEFAULT_LANGUAGE)
+    return SynonymWarmupResponse(status=status, detail=detail)
 
 
 @app.post(f"{API_PREFIX}/auth/login", response_model=TokenResponse, tags=["auth"])

--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -14,3 +14,4 @@ python-dotenv
 requests
 feedparser
 nltk>=3.9,<4
+fasttext-wheel>=0.9.2,<0.10

--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -13,3 +13,4 @@ psycopg2-binary
 python-dotenv
 requests
 feedparser
+nltk>=3.9,<4

--- a/Backend/tests/functional/test_synonyms.py
+++ b/Backend/tests/functional/test_synonyms.py
@@ -1,0 +1,46 @@
+"""Functional tests for alert synonym endpoint."""
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+from app.main import app, get_current_user
+
+
+@pytest.mark.integration
+class TestSynonymEndpoint:
+    async def test_generate_alert_synonyms(self, monkeypatch):
+        async def current_user_override():
+            return object()
+
+        app.dependency_overrides[get_current_user] = current_user_override
+        monkeypatch.setattr("app.main.generate_synonyms", lambda term, limit, language: ["auto", "carro", "vehiculo"])
+
+        try:
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.get("/api/v1/alerts/synonyms?term=coche&limit=3")
+        finally:
+            app.dependency_overrides.clear()
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["term"] == "coche"
+        assert data["language"] == "spa"
+        assert data["limit"] == 3
+        assert data["synonyms"] == ["auto", "carro", "vehiculo"]
+
+    async def test_generate_alert_synonyms_requires_auth(self):
+        async def unauthorized_override():
+            raise HTTPException(status_code=401, detail="Token inválido o ausente")
+
+        app.dependency_overrides[get_current_user] = unauthorized_override
+
+        try:
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.get("/api/v1/alerts/synonyms?term=coche&limit=3")
+        finally:
+            app.dependency_overrides.clear()
+
+        assert response.status_code == 401

--- a/Backend/tests/functional/test_synonyms.py
+++ b/Backend/tests/functional/test_synonyms.py
@@ -44,3 +44,55 @@ class TestSynonymEndpoint:
             app.dependency_overrides.clear()
 
         assert response.status_code == 401
+
+    async def test_warmup_synonyms_endpoint(self, monkeypatch):
+        async def current_user_override():
+            return object()
+
+        app.dependency_overrides[get_current_user] = current_user_override
+        monkeypatch.setattr("app.main.warmup_synonym_resources", lambda language: ("warmed", None))
+
+        try:
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.get("/api/v1/alerts/synonyms/warmup")
+        finally:
+            app.dependency_overrides.clear()
+
+        assert response.status_code == 200
+        assert response.json() == {"status": "warmed", "detail": None}
+
+    async def test_warmup_synonyms_endpoint_failure(self, monkeypatch):
+        async def current_user_override():
+            return object()
+
+        app.dependency_overrides[get_current_user] = current_user_override
+        monkeypatch.setattr(
+            "app.main.warmup_synonym_resources",
+            lambda language: ("failed", "Los corpus no estan disponibles"),
+        )
+
+        try:
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.get("/api/v1/alerts/synonyms/warmup")
+        finally:
+            app.dependency_overrides.clear()
+
+        assert response.status_code == 200
+        assert response.json() == {"status": "failed", "detail": "Los corpus no estan disponibles"}
+
+    async def test_warmup_synonyms_endpoint_requires_auth(self):
+        async def unauthorized_override():
+            raise HTTPException(status_code=401, detail="Token inválido o ausente")
+
+        app.dependency_overrides[get_current_user] = unauthorized_override
+
+        try:
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+                response = await client.get("/api/v1/alerts/synonyms/warmup")
+        finally:
+            app.dependency_overrides.clear()
+
+        assert response.status_code == 401

--- a/Backend/tests/unit/test_synonyms.py
+++ b/Backend/tests/unit/test_synonyms.py
@@ -1,0 +1,84 @@
+"""Unit tests for Spanish synonym generation."""
+
+import pytest
+
+from app.core import synonyms
+
+
+class FakeSynset:
+    def __init__(self, lemmas: list[str]) -> None:
+        self.lemmas = lemmas
+
+    def lemma_names(self, lang: str) -> list[str]:
+        assert lang == "spa"
+        return self.lemmas
+
+
+class FakeWordNet:
+    def __init__(self, synsets: list[FakeSynset]) -> None:
+        self._synsets = synsets
+
+    def synsets(self, term: str, lang: str) -> list[FakeSynset]:
+        assert term == "casa"
+        assert lang == "spa"
+        return self._synsets
+
+
+@pytest.mark.unit
+def test_spanish_synonym_lookup_returns_clean_results():
+    result = synonyms.generate_synonyms("coche", limit=10)
+
+    assert result
+    assert len(result) <= 10
+    assert "coche" not in result
+    assert len(result) == len(set(result))
+
+
+@pytest.mark.unit
+def test_deduplicates_and_excludes_original_term(monkeypatch):
+    fake_wordnet = FakeWordNet(
+        [
+            FakeSynset(["casa", "hogar", "Hogar", "vivienda"]),
+            FakeSynset(["casa", "vivienda", "domicilio"]),
+        ]
+    )
+    monkeypatch.setattr(synonyms, "wordnet", fake_wordnet)
+
+    result = synonyms.generate_synonyms("Casa", limit=10)
+
+    assert result == ["hogar", "vivienda", "domicilio"]
+
+
+@pytest.mark.unit
+def test_limit_is_clamped_to_supported_range(monkeypatch):
+    fake_wordnet = FakeWordNet(
+        [
+            FakeSynset(
+                [
+                    "casa",
+                    "hogar",
+                    "vivienda",
+                    "domicilio",
+                    "residencia",
+                    "morada",
+                    "piso",
+                    "apartamento",
+                    "inmueble",
+                    "habitacion",
+                    "alojamiento",
+                ]
+            )
+        ]
+    )
+    monkeypatch.setattr(synonyms, "wordnet", fake_wordnet)
+
+    assert synonyms.generate_synonyms("casa", limit=2) == ["hogar", "vivienda", "domicilio"]
+    assert len(synonyms.generate_synonyms("casa", limit=50)) == 10
+
+
+@pytest.mark.unit
+def test_no_results_returns_empty_list(monkeypatch):
+    fake_wordnet = FakeWordNet([])
+    monkeypatch.setattr(synonyms, "wordnet", fake_wordnet)
+
+    assert synonyms.generate_synonyms("casa", limit=10) == []

--- a/Backend/tests/unit/test_synonyms.py
+++ b/Backend/tests/unit/test_synonyms.py
@@ -5,6 +5,14 @@ import pytest
 from app.core import synonyms
 
 
+@pytest.fixture(autouse=True)
+def reset_synonym_optional_state(monkeypatch):
+    monkeypatch.delenv(synonyms.FASTTEXT_MODEL_PATH_ENV, raising=False)
+    synonyms._reset_warmup_state_for_tests()
+    yield
+    synonyms._reset_warmup_state_for_tests()
+
+
 class FakeSynset:
     def __init__(self, lemmas: list[str]) -> None:
         self.lemmas = lemmas
@@ -31,6 +39,16 @@ class MapWordNet:
     def synsets(self, term: str, lang: str) -> list[FakeSynset]:
         assert lang == "spa"
         return self.mapping.get(term, [])
+
+
+class FakeFastTextModel:
+    def __init__(self, mapping: dict[str, list[tuple[float, str]]]) -> None:
+        self.mapping = mapping
+        self.calls: list[tuple[str, int]] = []
+
+    def get_nearest_neighbors(self, term: str, k: int):
+        self.calls.append((term, k))
+        return self.mapping.get(term, [])[:k]
 
 
 @pytest.mark.unit
@@ -189,3 +207,128 @@ def test_generate_synonyms_works_after_warmup(monkeypatch):
     assert status == "warmed"
     assert detail is None
     assert result == ["auto", "vehiculo"]
+
+
+@pytest.mark.unit
+def test_fasttext_fallback_is_used_when_wordnet_returns_too_few_results(monkeypatch):
+    fake_wordnet = MapWordNet({"tecnologia": [FakeSynset(["técnica"])]})
+    fake_fasttext = FakeFastTextModel(
+        {
+            "tecnologia": [
+                (0.92, "ingenieria"),
+                (0.87, "tecnologia"),
+                (0.84, "http://basura"),
+                (0.81, "innovacion"),
+            ]
+        }
+    )
+    monkeypatch.setattr(synonyms, "wordnet", fake_wordnet)
+    monkeypatch.setattr(synonyms, "_get_fasttext_model", lambda: fake_fasttext)
+
+    result = synonyms.generate_synonyms("tecnologia", limit=4)
+
+    assert result == ["técnica", "ingenieria", "innovacion"]
+
+
+@pytest.mark.unit
+def test_fasttext_is_optional_when_model_is_not_configured(monkeypatch):
+    fake_wordnet = MapWordNet({"casa": [FakeSynset(["hogar"])]})
+    monkeypatch.setattr(synonyms, "wordnet", fake_wordnet)
+
+    result = synonyms.generate_synonyms("casa", limit=10)
+
+    assert result == ["hogar"]
+
+
+@pytest.mark.unit
+def test_missing_fasttext_model_path_is_handled_gracefully(monkeypatch, tmp_path):
+    fake_wordnet = MapWordNet({})
+    monkeypatch.setattr(synonyms, "wordnet", fake_wordnet)
+    monkeypatch.setenv(synonyms.FASTTEXT_MODEL_PATH_ENV, str(tmp_path / "missing.bin"))
+
+    result = synonyms.generate_synonyms("gpu", limit=10)
+
+    assert result == []
+
+
+@pytest.mark.unit
+def test_fasttext_deduplicates_excludes_original_and_filters_junk(monkeypatch):
+    fake_wordnet = MapWordNet({})
+    fake_fasttext = FakeFastTextModel(
+        {
+            "gpu": [
+                (0.95, "GPU"),
+                (0.91, "tarjeta"),
+                (0.88, "tarjeta"),
+                (0.84, "3"),
+                (0.82, "x"),
+                (0.8, "www.ejemplo.com"),
+                (0.78, "procesador"),
+            ]
+        }
+    )
+    monkeypatch.setattr(synonyms, "wordnet", fake_wordnet)
+    monkeypatch.setattr(synonyms, "_get_fasttext_model", lambda: fake_fasttext)
+
+    result = synonyms.generate_synonyms("GPU", limit=10)
+
+    assert result == ["tarjeta", "procesador"]
+
+
+@pytest.mark.unit
+def test_fasttext_limit_and_acronym_lookup_are_case_insensitive(monkeypatch):
+    fake_wordnet = MapWordNet({})
+    fake_fasttext = FakeFastTextModel(
+        {
+            "gpu": [
+                (0.96, "grafica"),
+                (0.94, "nvidia"),
+                (0.92, "hardware"),
+                (0.9, "cuda"),
+            ]
+        }
+    )
+    monkeypatch.setattr(synonyms, "wordnet", fake_wordnet)
+    monkeypatch.setattr(synonyms, "_get_fasttext_model", lambda: fake_fasttext)
+
+    assert synonyms.generate_synonyms("GPU", limit=2) == ["grafica", "nvidia", "hardware"]
+    assert synonyms.generate_synonyms("gpu", limit=2) == ["grafica", "nvidia", "hardware"]
+
+
+@pytest.mark.unit
+def test_wordnet_and_fallback_order_before_fasttext(monkeypatch):
+    fake_wordnet = MapWordNet({"ia": [FakeSynset(["inteligencia"])]})
+    fake_fasttext = FakeFastTextModel({"ia": [(0.99, "aprendizaje"), (0.98, "datos")]})
+    monkeypatch.setattr(synonyms, "wordnet", fake_wordnet)
+    monkeypatch.setattr(synonyms, "FALLBACK_SYNONYMS", {"ia": ["inteligencia artificial"]})
+    monkeypatch.setattr(synonyms, "_get_fasttext_model", lambda: fake_fasttext)
+
+    result = synonyms.generate_synonyms("IA", limit=10)
+
+    assert result == ["inteligencia", "inteligencia artificial", "aprendizaje", "datos"]
+
+
+@pytest.mark.unit
+def test_warmup_preloads_fasttext_when_configured(monkeypatch):
+    call_counter = {"wordnet": 0, "fasttext": 0}
+    fake_fasttext = FakeFastTextModel({synonyms.FASTTEXT_WARMUP_PROBE_TERM: [(0.9, "tecnica")]})
+
+    def fake_synsets_for(term: str, language: str):
+        call_counter["wordnet"] += 1
+        assert term == synonyms.WARMUP_PROBE_TERM
+        assert language == "spa"
+        return []
+
+    def fake_get_fasttext_model():
+        call_counter["fasttext"] += 1
+        return fake_fasttext
+
+    monkeypatch.setattr(synonyms, "_synsets_for", fake_synsets_for)
+    monkeypatch.setattr(synonyms, "_get_fasttext_model", fake_get_fasttext_model)
+
+    first_status, _ = synonyms.warmup_synonym_resources()
+    second_status, _ = synonyms.warmup_synonym_resources()
+
+    assert first_status == "warmed"
+    assert second_status == "already_warmed"
+    assert call_counter == {"wordnet": 1, "fasttext": 1}

--- a/Backend/tests/unit/test_synonyms.py
+++ b/Backend/tests/unit/test_synonyms.py
@@ -24,6 +24,15 @@ class FakeWordNet:
         return self._synsets
 
 
+class MapWordNet:
+    def __init__(self, mapping: dict[str, list[FakeSynset]]) -> None:
+        self.mapping = mapping
+
+    def synsets(self, term: str, lang: str) -> list[FakeSynset]:
+        assert lang == "spa"
+        return self.mapping.get(term, [])
+
+
 @pytest.mark.unit
 def test_spanish_synonym_lookup_returns_clean_results():
     result = synonyms.generate_synonyms("coche", limit=10)
@@ -82,3 +91,35 @@ def test_no_results_returns_empty_list(monkeypatch):
     monkeypatch.setattr(synonyms, "wordnet", fake_wordnet)
 
     assert synonyms.generate_synonyms("casa", limit=10) == []
+
+
+@pytest.mark.unit
+def test_fallback_for_ia_when_wordnet_has_no_results(monkeypatch):
+    fake_wordnet = MapWordNet({})
+    monkeypatch.setattr(synonyms, "wordnet", fake_wordnet)
+    monkeypatch.setattr(
+        synonyms,
+        "FALLBACK_SYNONYMS",
+        {"ia": ["inteligencia artificial", "aprendizaje automático", "ia"]},
+    )
+
+    result = synonyms.generate_synonyms("IA", limit=10)
+
+    assert result == ["inteligencia artificial", "aprendizaje automático"]
+
+
+@pytest.mark.unit
+def test_phrase_decomposition_for_multiword_terms(monkeypatch):
+    fake_wordnet = MapWordNet(
+        {
+            "inteligencia_artificial": [],
+            "inteligencia": [FakeSynset(["capacidad", "razón"])],
+            "artificial": [FakeSynset(["falso"])],
+        }
+    )
+    monkeypatch.setattr(synonyms, "wordnet", fake_wordnet)
+    monkeypatch.setattr(synonyms, "FALLBACK_SYNONYMS", {})
+
+    result = synonyms.generate_synonyms("inteligencia artificial", limit=10)
+
+    assert result == ["capacidad", "razón", "falso"]

--- a/Backend/tests/unit/test_synonyms.py
+++ b/Backend/tests/unit/test_synonyms.py
@@ -123,3 +123,69 @@ def test_phrase_decomposition_for_multiword_terms(monkeypatch):
     result = synonyms.generate_synonyms("inteligencia artificial", limit=10)
 
     assert result == ["capacidad", "razón", "falso"]
+
+
+@pytest.mark.unit
+def test_warmup_success_is_idempotent(monkeypatch):
+    call_counter = {"count": 0}
+    synonyms._reset_warmup_state_for_tests()
+
+    def fake_synsets_for(term: str, language: str):
+        call_counter["count"] += 1
+        assert term == synonyms.WARMUP_PROBE_TERM
+        assert language == "spa"
+        return []
+
+    monkeypatch.setattr(synonyms, "_synsets_for", fake_synsets_for)
+
+    first_status, first_detail = synonyms.warmup_synonym_resources()
+    second_status, second_detail = synonyms.warmup_synonym_resources()
+
+    assert first_status == "warmed"
+    assert first_detail is None
+    assert second_status == "already_warmed"
+    assert second_detail is None
+    assert call_counter["count"] == 1
+
+
+@pytest.mark.unit
+def test_warmup_failure_is_idempotent(monkeypatch):
+    call_counter = {"count": 0}
+    synonyms._reset_warmup_state_for_tests()
+
+    def fake_synsets_for(term: str, language: str):
+        call_counter["count"] += 1
+        raise synonyms.SynonymDataNotAvailableError("missing resources")
+
+    monkeypatch.setattr(synonyms, "_synsets_for", fake_synsets_for)
+
+    first_status, first_detail = synonyms.warmup_synonym_resources()
+    second_status, second_detail = synonyms.warmup_synonym_resources()
+
+    assert first_status == "failed"
+    assert first_detail == "missing resources"
+    assert second_status == "failed"
+    assert second_detail == "missing resources"
+    assert call_counter["count"] == 1
+
+
+@pytest.mark.unit
+def test_generate_synonyms_works_after_warmup(monkeypatch):
+    synonyms._reset_warmup_state_for_tests()
+    mapping = {
+        synonyms.WARMUP_PROBE_TERM: [FakeSynset([])],
+        "coche": [FakeSynset(["auto", "vehiculo"])],
+    }
+
+    def fake_synsets_for(term: str, language: str):
+        assert language == "spa"
+        return mapping.get(term, [])
+
+    monkeypatch.setattr(synonyms, "_synsets_for", fake_synsets_for)
+
+    status, detail = synonyms.warmup_synonym_resources()
+    result = synonyms.generate_synonyms("coche", limit=10)
+
+    assert status == "warmed"
+    assert detail is None
+    assert result == ["auto", "vehiculo"]

--- a/Frontend/src/pages/AlertsPage.jsx
+++ b/Frontend/src/pages/AlertsPage.jsx
@@ -1,6 +1,6 @@
-import React, { useState, useEffect } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { getAlerts, createAlert, deleteAlert, generateSynonyms } from '../services/alertsService';
+import { getAlerts, createAlert, deleteAlert, generateSynonyms, warmupSynonyms } from '../services/alertsService';
 import { getCategories } from '../services/sourcesService';
 
 const MIN_DESCRIPTORS = 3;
@@ -27,6 +27,7 @@ export default function AlertsPage() {
   const [showModal, setShowModal] = useState(false);
   const [synonymLoading, setSynonymLoading] = useState(false);
   const [synonymSuggestions, setSynonymSuggestions] = useState([]);
+  const hasWarmedSynonymsRef = useRef(false);
 
   const [formData, setFormData] = useState({
     name: '',
@@ -201,7 +202,22 @@ export default function AlertsPage() {
     }
   };
 
-  const openModal = () => { setError(null); setShowModal(true); };
+  const triggerSynonymWarmup = () => {
+    if (!token || hasWarmedSynonymsRef.current) {
+      return;
+    }
+    hasWarmedSynonymsRef.current = true;
+    warmupSynonyms(token).catch((err) => {
+      // El warmup no debe bloquear ni romper la UX del modal de alertas.
+      console.warn('[alerts] Synonym warmup failed:', err.message);
+    });
+  };
+
+  const openModal = () => {
+    setError(null);
+    triggerSynonymWarmup();
+    setShowModal(true);
+  };
   const closeModal = () => {
     setError(null);
     setSynonymSuggestions([]);

--- a/Frontend/src/pages/AlertsPage.jsx
+++ b/Frontend/src/pages/AlertsPage.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { getAlerts, createAlert, deleteAlert } from '../services/alertsService';
+import { getAlerts, createAlert, deleteAlert, generateSynonyms } from '../services/alertsService';
 import { getCategories } from '../services/sourcesService';
 
 // Presets comunes de expresión cron para el motor de captura RSS (Sprint 3.1)
@@ -22,6 +22,7 @@ export default function AlertsPage() {
   const [categories, setCategories] = useState([]);
   const [error, setError] = useState(null);
   const [showModal, setShowModal] = useState(false);
+  const [synonymLoading, setSynonymLoading] = useState(false);
 
   const [formData, setFormData] = useState({
     name: '',
@@ -117,6 +118,32 @@ export default function AlertsPage() {
       fetchAlerts();
     } catch (err) {
       setError(err.message);
+    }
+  };
+
+  const handleGenerateSynonyms = async () => {
+    setError(null);
+    const baseTerm = formData.descriptors
+      .split(',')
+      .map((d) => d.trim())
+      .filter((d) => d !== '')[0];
+
+    if (!baseTerm) {
+      return setError('Introduce un término base para generar sinónimos.');
+    }
+
+    setSynonymLoading(true);
+    try {
+      const data = await generateSynonyms(token, baseTerm, 10);
+      if (!data.synonyms || data.synonyms.length < 3) {
+        return setError(`No se encontraron suficientes sinónimos para "${baseTerm}".`);
+      }
+
+      setFormData({ ...formData, descriptors: data.synonyms.join(', ') });
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setSynonymLoading(false);
     }
   };
 
@@ -228,14 +255,24 @@ export default function AlertsPage() {
 
                   <div className="mb-3">
                     <label className="form-label">DESCRIPTORES / PALABRAS CLAVE (separados por coma)</label>
-                    <input
-                      type="text"
-                      className="form-control bg-light"
-                      placeholder="IA, ROBÓTICA, CHIPS"
-                      value={formData.descriptors}
-                      onChange={(e) => setFormData({ ...formData, descriptors: e.target.value })}
-                      required
-                    />
+                    <div className="input-group">
+                      <input
+                        type="text"
+                        className="form-control bg-light"
+                        placeholder="IA, ROBÓTICA, CHIPS"
+                        value={formData.descriptors}
+                        onChange={(e) => setFormData({ ...formData, descriptors: e.target.value })}
+                        required
+                      />
+                      <button
+                        type="button"
+                        className="btn btn-outline-dark"
+                        onClick={handleGenerateSynonyms}
+                        disabled={synonymLoading}
+                      >
+                        {synonymLoading ? 'GENERANDO...' : 'GENERAR SINÓNIMOS'}
+                      </button>
+                    </div>
                     <small className="text-muted">Introduce entre 3 y 10 palabras.</small>
                   </div>
 

--- a/Frontend/src/pages/AlertsPage.jsx
+++ b/Frontend/src/pages/AlertsPage.jsx
@@ -3,6 +3,9 @@ import { Link } from 'react-router-dom';
 import { getAlerts, createAlert, deleteAlert, generateSynonyms } from '../services/alertsService';
 import { getCategories } from '../services/sourcesService';
 
+const MIN_DESCRIPTORS = 3;
+const MAX_DESCRIPTORS = 10;
+
 // Presets comunes de expresión cron para el motor de captura RSS (Sprint 3.1)
 const CRON_PRESETS = [
   { label: 'Cada 15 minutos', value: '*/15 * * * *' },
@@ -23,6 +26,7 @@ export default function AlertsPage() {
   const [error, setError] = useState(null);
   const [showModal, setShowModal] = useState(false);
   const [synonymLoading, setSynonymLoading] = useState(false);
+  const [synonymSuggestions, setSynonymSuggestions] = useState([]);
 
   const [formData, setFormData] = useState({
     name: '',
@@ -31,6 +35,26 @@ export default function AlertsPage() {
     cron_expression: '0 0 * * *',
     category_ids: [],
   });
+
+  const parseDescriptors = (descriptorsRaw) => {
+    const parsedDescriptors = descriptorsRaw
+      .split(',')
+      .map((descriptor) => descriptor.trim())
+      .filter((descriptor) => descriptor !== '');
+
+    const dedupedDescriptors = [];
+    const seen = new Set();
+    parsedDescriptors.forEach((descriptor) => {
+      const normalizedDescriptor = descriptor.toLowerCase();
+      if (!seen.has(normalizedDescriptor)) {
+        seen.add(normalizedDescriptor);
+        dedupedDescriptors.push(descriptor);
+      }
+    });
+    return dedupedDescriptors;
+  };
+
+  const descriptorsList = parseDescriptors(formData.descriptors);
 
   const fetchAlerts = async () => {
     try {
@@ -76,15 +100,12 @@ export default function AlertsPage() {
     e.preventDefault();
     setError(null);
 
-    const parsedDescriptors = formData.descriptors
-      .split(',')
-      .map((d) => d.trim())
-      .filter((d) => d !== '');
+    const parsedDescriptors = parseDescriptors(formData.descriptors);
 
     if (alerts.length >= 20) {
       return setError('Límite máximo de 20 alertas alcanzado.');
     }
-    if (parsedDescriptors.length < 3 || parsedDescriptors.length > 10) {
+    if (parsedDescriptors.length < MIN_DESCRIPTORS || parsedDescriptors.length > MAX_DESCRIPTORS) {
       return setError('Debes incluir entre 3 y 10 descriptores separados por coma.');
     }
     if (!formData.cron_expression.trim()) {
@@ -115,6 +136,7 @@ export default function AlertsPage() {
         cron_expression: '0 0 * * *',
         category_ids: [],
       });
+      setSynonymSuggestions([]);
       fetchAlerts();
     } catch (err) {
       setError(err.message);
@@ -123,28 +145,50 @@ export default function AlertsPage() {
 
   const handleGenerateSynonyms = async () => {
     setError(null);
-    const baseTerm = formData.descriptors
-      .split(',')
-      .map((d) => d.trim())
-      .filter((d) => d !== '')[0];
-
-    if (!baseTerm) {
-      return setError('Introduce un término base para generar sinónimos.');
+    if (descriptorsList.length === 0) {
+      return setError('Introduce al menos un descriptor para generar sinónimos.');
     }
 
     setSynonymLoading(true);
     try {
-      const data = await generateSynonyms(token, baseTerm, 10);
-      if (!data.synonyms || data.synonyms.length < 3) {
-        return setError(`No se encontraron suficientes sinónimos para "${baseTerm}".`);
-      }
+      const suggestionsByDescriptor = await Promise.all(
+        descriptorsList.map(async (descriptor) => {
+          const data = await generateSynonyms(token, descriptor, MAX_DESCRIPTORS);
+          return {
+            descriptor,
+            synonyms: data.synonyms || [],
+          };
+        })
+      );
 
-      setFormData({ ...formData, descriptors: data.synonyms.join(', ') });
+      setSynonymSuggestions(suggestionsByDescriptor);
+      const hasAnySynonym = suggestionsByDescriptor.some((group) => group.synonyms.length > 0);
+      if (!hasAnySynonym) {
+        setError('No se encontraron sinónimos para los descriptores indicados.');
+      }
     } catch (err) {
       setError(err.message);
     } finally {
       setSynonymLoading(false);
     }
+  };
+
+  const handleAddSynonym = (synonym) => {
+    setError(null);
+    const normalizedSynonym = synonym.toLowerCase();
+    const descriptorSet = new Set(descriptorsList.map((descriptor) => descriptor.toLowerCase()));
+
+    if (descriptorSet.has(normalizedSynonym)) {
+      return;
+    }
+
+    if (descriptorsList.length >= MAX_DESCRIPTORS) {
+      setError('Ya tienes 10 descriptores. Elimina uno antes de añadir más.');
+      return;
+    }
+
+    const nextDescriptors = [...descriptorsList, synonym];
+    setFormData({ ...formData, descriptors: nextDescriptors.join(', ') });
   };
 
   const handleDelete = async (alertId) => {
@@ -158,7 +202,11 @@ export default function AlertsPage() {
   };
 
   const openModal = () => { setError(null); setShowModal(true); };
-  const closeModal = () => { setError(null); setShowModal(false); };
+  const closeModal = () => {
+    setError(null);
+    setSynonymSuggestions([]);
+    setShowModal(false);
+  };
 
   return (
     <div className="container mt-4">
@@ -261,7 +309,10 @@ export default function AlertsPage() {
                         className="form-control bg-light"
                         placeholder="IA, ROBÓTICA, CHIPS"
                         value={formData.descriptors}
-                        onChange={(e) => setFormData({ ...formData, descriptors: e.target.value })}
+                        onChange={(e) => {
+                          setFormData({ ...formData, descriptors: e.target.value });
+                          setSynonymSuggestions([]);
+                        }}
                         required
                       />
                       <button
@@ -273,8 +324,43 @@ export default function AlertsPage() {
                         {synonymLoading ? 'GENERANDO...' : 'GENERAR SINÓNIMOS'}
                       </button>
                     </div>
-                    <small className="text-muted">Introduce entre 3 y 10 palabras.</small>
+                    <small className="text-muted">
+                      Introduce entre 3 y 10 palabras. ({descriptorsList.length}/{MAX_DESCRIPTORS})
+                    </small>
                   </div>
+
+                  {synonymSuggestions.length > 0 && (
+                    <div className="mb-3">
+                      <label className="form-label">SUGERENCIAS DE SINÓNIMOS</label>
+                      {synonymSuggestions.map((group) => (
+                        <div key={group.descriptor} className="mb-2">
+                          <div className="small text-muted mb-1">{group.descriptor}</div>
+                          {group.synonyms.length === 0 ? (
+                            <div className="small text-muted">No se encontraron sinónimos.</div>
+                          ) : (
+                            <div className="d-flex flex-wrap gap-2">
+                              {group.synonyms.map((synonym) => {
+                                const alreadySelected = descriptorsList
+                                  .map((descriptor) => descriptor.toLowerCase())
+                                  .includes(synonym.toLowerCase());
+                                return (
+                                  <button
+                                    type="button"
+                                    key={`${group.descriptor}-${synonym}`}
+                                    className={`btn btn-sm ${alreadySelected ? 'btn-secondary' : 'btn-outline-secondary'}`}
+                                    onClick={() => handleAddSynonym(synonym)}
+                                    disabled={alreadySelected}
+                                  >
+                                    {synonym}
+                                  </button>
+                                );
+                              })}
+                            </div>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  )}
 
                   <div className="row">
                     <div className="col-md-6 mb-3">

--- a/Frontend/src/services/alertsService.js
+++ b/Frontend/src/services/alertsService.js
@@ -33,3 +33,19 @@ export const deleteAlert = async (userId, token, alertId) => {
   if (!response.ok) throw new Error('Error al eliminar la alerta');
   return true;
 };
+
+export const generateSynonyms = async (token, term, limit = 10) => {
+  const params = new URLSearchParams({
+    term,
+    limit: String(limit)
+  });
+  const response = await fetch(`${API_URL}/alerts/synonyms?${params.toString()}`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.detail || 'Error al generar sinónimos');
+  }
+  return response.json();
+};

--- a/Frontend/src/services/alertsService.js
+++ b/Frontend/src/services/alertsService.js
@@ -49,3 +49,15 @@ export const generateSynonyms = async (token, term, limit = 10) => {
   }
   return response.json();
 };
+
+export const warmupSynonyms = async (token) => {
+  const response = await fetch(`${API_URL}/alerts/synonyms/warmup`, {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.detail || 'Error al precalentar sinónimos');
+  }
+  return response.json();
+};

--- a/Frontend/src/test/AlertsPageSynonyms.test.jsx
+++ b/Frontend/src/test/AlertsPageSynonyms.test.jsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AlertsPage from '../pages/AlertsPage';
+import { generateSynonyms, getAlerts } from '../services/alertsService';
+import { getCategories } from '../services/sourcesService';
+
+vi.mock('../services/alertsService', () => ({
+  getAlerts: vi.fn(),
+  createAlert: vi.fn(),
+  deleteAlert: vi.fn(),
+  generateSynonyms: vi.fn()
+}));
+
+vi.mock('../services/sourcesService', () => ({
+  getCategories: vi.fn()
+}));
+
+describe('AlertsPage synonym generation', () => {
+  beforeEach(() => {
+    const storage = {};
+    Object.defineProperty(window, 'localStorage', {
+      value: {
+        getItem: (key) => storage[key] || null,
+        setItem: (key, value) => {
+          storage[key] = String(value);
+        },
+        removeItem: (key) => {
+          delete storage[key];
+        },
+        clear: () => {
+          Object.keys(storage).forEach((key) => {
+            delete storage[key];
+          });
+        }
+      },
+      configurable: true
+    });
+    window.localStorage.setItem('token', 'token-test');
+    window.localStorage.setItem('userId', '42');
+    vi.clearAllMocks();
+    getAlerts.mockResolvedValue([]);
+    getCategories.mockResolvedValue([]);
+  });
+
+  const openModal = async () => {
+    render(
+      <MemoryRouter>
+        <AlertsPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /\+ nueva alerta/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/crear nueva alerta/i)).toBeInTheDocument();
+    });
+  };
+
+  it('generates suggestions for each descriptor and appends selected synonym', async () => {
+    generateSynonyms
+      .mockResolvedValueOnce({ term: 'ia', language: 'spa', limit: 10, synonyms: ['inteligencia artificial'] })
+      .mockResolvedValueOnce({ term: 'coche', language: 'spa', limit: 10, synonyms: ['auto'] });
+
+    await openModal();
+
+    const descriptorsInput = screen.getByPlaceholderText(/ia, robótica, chips/i);
+    fireEvent.change(descriptorsInput, { target: { value: 'ia, coche' } });
+    fireEvent.click(screen.getByRole('button', { name: /generar sinónimos/i }));
+
+    await waitFor(() => {
+      expect(generateSynonyms).toHaveBeenCalledTimes(2);
+    });
+
+    expect(generateSynonyms).toHaveBeenNthCalledWith(1, 'token-test', 'ia', 10);
+    expect(generateSynonyms).toHaveBeenNthCalledWith(2, 'token-test', 'coche', 10);
+    expect(descriptorsInput).toHaveValue('ia, coche');
+
+    fireEvent.click(screen.getByRole('button', { name: 'auto' }));
+    expect(descriptorsInput).toHaveValue('ia, coche, auto');
+  });
+
+  it('prevents adding extra descriptor by suggestion when max limit is reached', async () => {
+    generateSynonyms.mockImplementation(async (_, term) => ({
+      term,
+      language: 'spa',
+      limit: 10,
+      synonyms: [`${term}-syn`]
+    }));
+
+    await openModal();
+
+    const descriptorsInput = screen.getByPlaceholderText(/ia, robótica, chips/i);
+    const tenDescriptors = 'a,b,c,d,e,f,g,h,i,j';
+    fireEvent.change(descriptorsInput, { target: { value: tenDescriptors } });
+    fireEvent.click(screen.getByRole('button', { name: /generar sinónimos/i }));
+
+    await waitFor(() => {
+      expect(generateSynonyms).toHaveBeenCalledTimes(10);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'a-syn' }));
+    expect(screen.getByText(/ya tienes 10 descriptores/i)).toBeInTheDocument();
+    expect(descriptorsInput).toHaveValue(tenDescriptors);
+  });
+});

--- a/Frontend/src/test/AlertsPageSynonyms.test.jsx
+++ b/Frontend/src/test/AlertsPageSynonyms.test.jsx
@@ -4,14 +4,15 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import AlertsPage from '../pages/AlertsPage';
-import { generateSynonyms, getAlerts } from '../services/alertsService';
+import { generateSynonyms, getAlerts, warmupSynonyms } from '../services/alertsService';
 import { getCategories } from '../services/sourcesService';
 
 vi.mock('../services/alertsService', () => ({
   getAlerts: vi.fn(),
   createAlert: vi.fn(),
   deleteAlert: vi.fn(),
-  generateSynonyms: vi.fn()
+  generateSynonyms: vi.fn(),
+  warmupSynonyms: vi.fn()
 }));
 
 vi.mock('../services/sourcesService', () => ({
@@ -43,6 +44,7 @@ describe('AlertsPage synonym generation', () => {
     vi.clearAllMocks();
     getAlerts.mockResolvedValue([]);
     getCategories.mockResolvedValue([]);
+    warmupSynonyms.mockResolvedValue({ status: 'warmed' });
   });
 
   const openModal = async () => {
@@ -103,5 +105,20 @@ describe('AlertsPage synonym generation', () => {
     fireEvent.click(screen.getByRole('button', { name: 'a-syn' }));
     expect(screen.getByText(/ya tienes 10 descriptores/i)).toBeInTheDocument();
     expect(descriptorsInput).toHaveValue(tenDescriptors);
+  });
+
+  it('triggers synonym warmup once when opening the alert modal', async () => {
+    await openModal();
+    await waitFor(() => {
+      expect(warmupSynonyms).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /cancelar/i }));
+    fireEvent.click(screen.getByRole('button', { name: /\+ nueva alerta/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/crear nueva alerta/i)).toBeInTheDocument();
+    });
+    expect(warmupSynonyms).toHaveBeenCalledTimes(1);
   });
 });

--- a/Frontend/src/test/alertsService.test.js
+++ b/Frontend/src/test/alertsService.test.js
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { generateSynonyms } from '../services/alertsService';
+
+describe('alertsService', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('requests Spanish synonyms with the configured limit', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ term: 'coche', language: 'spa', limit: 3, synonyms: ['auto', 'carro', 'vehiculo'] })
+    });
+
+    const result = await generateSynonyms('token-123', 'coche', 3);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:8000/api/v1/alerts/synonyms?term=coche&limit=3',
+      { headers: { Authorization: 'Bearer token-123' } }
+    );
+    expect(result.synonyms).toEqual(['auto', 'carro', 'vehiculo']);
+  });
+
+  it('raises the backend error message when synonym generation fails', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      json: async () => ({ detail: 'No disponible' })
+    });
+
+    await expect(generateSynonyms('token-123', 'x', 3)).rejects.toThrow('No disponible');
+  });
+});

--- a/Frontend/src/test/alertsService.test.js
+++ b/Frontend/src/test/alertsService.test.js
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { generateSynonyms } from '../services/alertsService';
+import { generateSynonyms, warmupSynonyms } from '../services/alertsService';
 
 describe('alertsService', () => {
   afterEach(() => {
@@ -28,5 +28,20 @@ describe('alertsService', () => {
     });
 
     await expect(generateSynonyms('token-123', 'x', 3)).rejects.toThrow('No disponible');
+  });
+
+  it('calls synonym warmup endpoint with auth header', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ status: 'warmed' })
+    });
+
+    const result = await warmupSynonyms('token-123');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:8000/api/v1/alerts/synonyms/warmup',
+      { headers: { Authorization: 'Bearer token-123' } }
+    );
+    expect(result.status).toBe('warmed');
   });
 });

--- a/README.md
+++ b/README.md
@@ -33,6 +33,25 @@ Backend: http://localhost:8000 | Frontend: http://localhost:5173 | API Docs: htt
 
 ## Development
 
+### Local fastText Synonym Fallback
+
+The Spanish synonym feature can optionally use local fastText vectors for
+related-term suggestions when WordNet has low coverage. Use the binary model
+(`.bin`), not the text vectors file (`.vec`).
+
+```bash
+# Download Spanish fastText vectors to .models/fasttext/cc.es.300.bin
+scripts/download-fasttext-es.sh
+
+# Start backend + frontend with the optional fastText fallback enabled
+scripts/start-dev.sh --both-parallel --fasttext
+
+# Or use a custom binary model path
+scripts/start-dev.sh --both-parallel --fasttext-model /path/to/cc.es.300.bin
+```
+
+The model file is local-only and is not committed to the repository.
+
 ### Quality Checks
 
 ```bash
@@ -88,6 +107,7 @@ See [docs/deployment/cicd.md](docs/deployment/cicd.md) for full pipeline details
 | `scripts/check.sh` | Quick lint + typecheck + unit tests |
 | `scripts/ci-local.sh` | Full CI pipeline locally |
 | `scripts/gen-docs.sh` | Export OpenAPI documentation |
+| `scripts/download-fasttext-es.sh` | Download optional Spanish fastText vectors |
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,14 @@ Backend: http://localhost:8000 | Frontend: http://localhost:5173 | API Docs: htt
 ### Local fastText Synonym Fallback
 
 The Spanish synonym feature can optionally use local fastText vectors for
-related-term suggestions when WordNet has low coverage. Use the binary model
-(`.bin`), not the text vectors file (`.vec`).
+related-term suggestions when WordNet has low coverage. This path is
+**experimental**: fastText returns semantically related terms, not guaranteed
+strict synonyms, and it should not be enabled for normal production deployments
+unless the team has validated the model quality and memory footprint for that
+environment. It is available for local evaluation or deployments that explicitly
+want to try broader vocabulary coverage.
+
+Use the binary model (`.bin`), not the text vectors file (`.vec`).
 
 ```bash
 # Download Spanish fastText vectors to .models/fasttext/cc.es.300.bin

--- a/docs/adr/0016-generacion-sinonimos-wordnet.md
+++ b/docs/adr/0016-generacion-sinonimos-wordnet.md
@@ -1,0 +1,115 @@
+# ADR 0016: Generación local de sinónimos con NLTK WordNet
+
+- **Estado:** Aceptado
+- **Fecha:** 2026-04-27
+- **Autores:** Equipo DevOps (Konstantin Rannev, Álvaro Rodriguez) y Backend
+- **Reemplaza a:** —
+- **Relacionado con:** [ADR 0001](0001-framework-backend-fastapi.md), [ADR 0009](0009-estrategia-testing-pytest-vitest-playwright.md), [ADR 0014](0014-integracion-api-gestion-fuentes-alertas.md)
+
+---
+
+## Contexto
+
+La creación de alertas requiere introducir entre 3 y 10 descriptores o palabras
+clave. Para reducir trabajo manual y mejorar la cobertura de búsquedas en
+castellano, se necesita generar sinónimos para un término base dentro del flujo
+normal de alta de alertas.
+
+La solución debía cumplir varias restricciones:
+
+- No depender de APIs externas, servicios alojados ni costes de uso.
+- No introducir un servidor local adicional de IA, como Ollama, salvo necesidad
+  justificada.
+- Priorizar castellano como idioma principal.
+- Mantener una solución ligera, determinista y sencilla de operar en la
+  arquitectura actual de backend FastAPI y frontend.
+
+## Decisión
+
+Se decide implementar la generación de sinónimos en el backend mediante
+**NLTK WordNet** y el corpus **omw-1.4** de Open Multilingual WordNet.
+
+El backend expone un endpoint autenticado para el flujo de alertas:
+
+- `GET /api/v1/alerts/synonyms?term=<termino>&limit=<3-10>`
+
+La lógica queda encapsulada en `app/core/synonyms.py` y aplica:
+
+- Normalización de espacios, guiones bajos y capitalización.
+- Búsqueda en WordNet usando el idioma `spa`.
+- Variantes simples para plurales frecuentes en castellano.
+- Limpieza, deduplicación y exclusión del término original.
+- Límite configurable dentro del rango soportado de 3 a 10 resultados.
+
+## Justificación
+
+- **Simplicidad operativa:** NLTK se ejecuta dentro del proceso del backend y no
+  requiere nuevos contenedores, workers ni servicios locales.
+- **Coste cero:** WordNet y Open Multilingual WordNet son recursos locales y no
+  generan llamadas a proveedores externos.
+- **Determinismo:** La respuesta depende de corpus versionados y reglas locales,
+  no de prompts, sampling ni disponibilidad de un modelo remoto.
+- **Buen soporte inicial en castellano:** OMW permite consultar lemas en español
+  mediante `lang="spa"`, suficiente para el caso de uso de descriptores.
+- **Extensibilidad:** La separación en un módulo de core permite sustituir o
+  enriquecer la fuente léxica más adelante sin cambiar el contrato del frontend.
+
+## Alternativas consideradas
+
+### LLM local
+
+Se descartó introducir un LLM local porque aumenta el consumo de CPU/RAM, añade
+dependencias operativas y requiere gestionar modelos, arranque y salud de un
+proceso adicional. Para generar una lista corta de sinónimos, el coste y la
+complejidad no están justificados.
+
+### APIs externas de lenguaje
+
+Se descartaron porque incumplen la restricción de no usar servicios alojados o
+potencialmente de pago, y añaden dependencia de red y proveedor.
+
+### Diccionario propio en base de datos
+
+Se descartó como solución inicial porque obligaría a mantener datos léxicos
+manualmente. Puede ser una extensión futura si el dominio periodístico necesita
+sinónimos curados.
+
+## Consecuencias
+
+### Positivas
+
+- La funcionalidad queda disponible para el frontend sin cambiar el modelo de
+  datos de alertas.
+- El comportamiento ante términos sin resultados es simple: se devuelve una
+  lista vacía y la interfaz mantiene la entrada manual.
+- La ejecución es rápida y local para listas cortas de descriptores.
+
+### Riesgos / costes
+
+- El paquete `nltk` no incluye los corpus por defecto. Los datos `wordnet` y
+  `omw-1.4` deben instalarse en CI, en la imagen Docker y en entornos locales.
+- La cobertura léxica de OMW no es equivalente a un tesauro especializado; puede
+  haber términos periodísticos, nombres propios o neologismos sin resultados.
+- La lematización en castellano se mantiene deliberadamente ligera; no se añade
+  una dependencia pesada de NLP para este caso de uso.
+
+## Implicaciones de testing
+
+Se añaden pruebas unitarias para:
+
+- Búsqueda básica de sinónimos en castellano.
+- Deduplicación.
+- Exclusión del término original.
+- Manejo del límite de resultados.
+- Comportamiento sin resultados.
+
+También se añade una prueba funcional del endpoint del backend y una prueba del
+servicio de frontend que consume la API.
+
+## Implicaciones operativas
+
+La imagen Docker descarga `wordnet` y `omw-1.4` durante el build. La pipeline de
+CI instala los mismos corpus antes de ejecutar las pruebas que los necesitan.
+
+Si los corpus no están disponibles en runtime, el backend devuelve `503` para el
+endpoint de sinónimos en lugar de fallar con un error interno.

--- a/docs/adr/0016-generacion-sinonimos-wordnet.md
+++ b/docs/adr/0016-generacion-sinonimos-wordnet.md
@@ -68,6 +68,12 @@ mediante `NEWSRADAR_FASTTEXT_MODEL_PATH`. Si la variable no está definida, el
 fichero no existe o el paquete no está disponible, el backend deshabilita esa
 capa y conserva el comportamiento WordNet/OMW.
 
+La capa fastText queda marcada como experimental. No se recomienda activarla en
+producción por defecto porque entrega términos relacionados, no sinónimos
+estrictos, y porque su calidad y consumo de memoria dependen del modelo local
+elegido. Se mantiene como opción explícita para entornos que quieran evaluar
+mayor cobertura de vocabulario.
+
 ## Justificación
 
 - **Simplicidad operativa:** NLTK se ejecuta dentro del proceso del backend y no
@@ -190,7 +196,9 @@ CI instala los mismos corpus antes de ejecutar las pruebas que los necesitan.
 El paquete Python compatible con fastText se instala con las dependencias del
 backend, pero el fichero de vectores es opcional y externo. En producción puede
 apuntarse `NEWSRADAR_FASTTEXT_MODEL_PATH` a un modelo español preentrenado de
-fastText. Si falta, se registra un aviso y se continúa con WordNet/OMW.
+fastText, aunque esta ruta se considera experimental y no forma parte del
+comportamiento productivo normal. Si falta, se registra un aviso y se continúa
+con WordNet/OMW.
 
 Si los corpus no están disponibles en runtime, el backend devuelve `503` para el
 endpoint de sinónimos en lugar de fallar con un error interno.

--- a/docs/adr/0016-generacion-sinonimos-wordnet.md
+++ b/docs/adr/0016-generacion-sinonimos-wordnet.md
@@ -38,6 +38,8 @@ La lógica queda encapsulada en `app/core/synonyms.py` y aplica:
 - Normalización de espacios, guiones bajos y capitalización.
 - Búsqueda en WordNet usando el idioma `spa`.
 - Variantes simples para plurales frecuentes en castellano.
+- Fallback léxico local para alias/acrónimos frecuentes (por ejemplo `ia`).
+- Descomposición de frases en tokens cuando no hay entrada directa útil.
 - Limpieza, deduplicación y exclusión del término original.
 - Límite configurable dentro del rango soportado de 3 a 10 resultados.
 
@@ -73,6 +75,13 @@ potencialmente de pago, y añaden dependencia de red y proveedor.
 Se descartó como solución inicial porque obligaría a mantener datos léxicos
 manualmente. Puede ser una extensión futura si el dominio periodístico necesita
 sinónimos curados.
+
+### Modelo local pequeño (SmolLM2 u otros)
+
+Se mantiene fuera de alcance en esta iteración por coste operativo y huella de
+runtime (modelos, carga en memoria y latencia), además de introducir
+comportamiento menos determinista para un flujo que se beneficia de reglas
+léxicas estables.
 
 ## Consecuencias
 

--- a/docs/adr/0016-generacion-sinonimos-wordnet.md
+++ b/docs/adr/0016-generacion-sinonimos-wordnet.md
@@ -2,7 +2,7 @@
 
 - **Estado:** Aceptado
 - **Fecha:** 2026-04-27
-- **Autores:** Equipo DevOps (Konstantin Rannev, Álvaro Rodriguez) y Backend
+- **Autores:** Equipo DevOps (Konstantin Rannev, Álvaro Rodriguez) y Backend (Alberto Nuñez, Francisco Ruiz)
 - **Reemplaza a:** —
 - **Relacionado con:** [ADR 0001](0001-framework-backend-fastapi.md), [ADR 0009](0009-estrategia-testing-pytest-vitest-playwright.md), [ADR 0014](0014-integracion-api-gestion-fuentes-alertas.md)
 

--- a/docs/adr/0016-generacion-sinonimos-wordnet.md
+++ b/docs/adr/0016-generacion-sinonimos-wordnet.md
@@ -18,6 +18,12 @@ normal de alta de alertas.
 Además, se observó latencia perceptible en la primera petición de sinónimos
 porque NLTK/OMW inicializa parte de los recursos de forma perezosa en memoria.
 
+Tras la primera implementación, se detectó que WordNet/OMW no cubre bien parte
+del vocabulario típico de RSS, noticias y tecnología. Términos como
+`tecnología`, `ingeniería` o `gpu` pueden devolver pocos resultados o ninguno.
+El producto necesita mantener resultados precisos cuando WordNet existe, pero
+también ofrecer sugerencias relacionadas para vocabulario arbitrario.
+
 La solución debía cumplir varias restricciones:
 
 - No depender de APIs externas, servicios alojados ni costes de uso.
@@ -30,7 +36,8 @@ La solución debía cumplir varias restricciones:
 ## Decisión
 
 Se decide implementar la generación de sinónimos en el backend mediante
-**NLTK WordNet** y el corpus **omw-1.4** de Open Multilingual WordNet.
+**NLTK WordNet** y el corpus **omw-1.4** de Open Multilingual WordNet, con una
+capa opcional de **fastText** como fallback de términos relacionados.
 
 El backend expone un endpoint autenticado para el flujo de alertas:
 
@@ -44,10 +51,22 @@ La lógica queda encapsulada en `app/core/synonyms.py` y aplica:
 - Variantes simples para plurales frecuentes en castellano.
 - Fallback léxico local para alias/acrónimos frecuentes (por ejemplo `ia`).
 - Descomposición de frases en tokens cuando no hay entrada directa útil.
+- Fallback opcional con vectores fastText locales cuando WordNet no alcanza el
+  límite configurado.
 - Warmup idempotente en backend para precargar recursos NLTK/OMW mediante una
-  consulta inocua.
+  consulta inocua y, si está configurado, cargar el modelo fastText.
 - Limpieza, deduplicación y exclusión del término original.
 - Límite configurable dentro del rango soportado de 3 a 10 resultados.
+
+El orden de resultados es determinista: primero WordNet/OMW, después alias
+léxicos locales y finalmente candidatos fastText ordenados por similitud del
+modelo. Los candidatos fastText se tratan explícitamente como términos
+relacionados, no como sinónimos estrictos.
+
+El modelo fastText no se descarga en runtime. La ruta del modelo se configura
+mediante `NEWSRADAR_FASTTEXT_MODEL_PATH`. Si la variable no está definida, el
+fichero no existe o el paquete no está disponible, el backend deshabilita esa
+capa y conserva el comportamiento WordNet/OMW.
 
 ## Justificación
 
@@ -63,6 +82,10 @@ La lógica queda encapsulada en `app/core/synonyms.py` y aplica:
   enriquecer la fuente léxica más adelante sin cambiar el contrato del frontend.
 - **Mejor UX inicial:** El warmup reduce la latencia visible de la primera
   generación de sinónimos sin bloquear el flujo de creación de alertas.
+- **Mayor cobertura:** fastText aporta vecinos semánticos para vocabulario
+  técnico o periodístico que no aparece en WordNet/OMW.
+- **Fallback local:** fastText mantiene el requisito de coste cero y ejecución
+  local, sin introducir un LLM ni un proceso servidor adicional.
 
 ## Alternativas consideradas
 
@@ -84,12 +107,25 @@ Se descartó como solución inicial porque obligaría a mantener datos léxicos
 manualmente. Puede ser una extensión futura si el dominio periodístico necesita
 sinónimos curados.
 
+### ConceptNet
+
+Se descartó como dependencia principal porque introduce una fuente más amplia
+pero menos controlada para este flujo, y su integración local exigiría gestionar
+datos adicionales. Puede reevaluarse si se necesita una base semántica
+explícita, no solo similitud vectorial.
+
 ### Modelo local pequeño (SmolLM2 u otros)
 
 Se mantiene fuera de alcance en esta iteración por coste operativo y huella de
 runtime (modelos, carga en memoria y latencia), además de introducir
 comportamiento menos determinista para un flujo que se beneficia de reglas
 léxicas estables.
+
+### fastText como fuente principal
+
+Se descartó porque sus vecinos vectoriales son términos semánticamente
+relacionados, no necesariamente sinónimos. WordNet/OMW sigue siendo la fuente
+de mayor precisión y fastText solo completa resultados cuando falta cobertura.
 
 ## Consecuencias
 
@@ -107,6 +143,16 @@ léxicas estables.
   `omw-1.4` deben instalarse en CI, en la imagen Docker y en entornos locales.
 - La cobertura léxica de OMW no es equivalente a un tesauro especializado; puede
   haber términos periodísticos, nombres propios o neologismos sin resultados.
+- La cobertura fastText depende de que exista un fichero de vectores local en
+  `NEWSRADAR_FASTTEXT_MODEL_PATH`. La aplicación no lo descarga ni lo versiona
+  en el repositorio.
+- Los modelos fastText preentrenados pueden ocupar cientos de MB o más, por lo
+  que su uso tiene impacto en almacenamiento, memoria y tiempo de carga. Por
+  eso se cargan de forma perezosa y el warmup solo los precarga si están
+  configurados.
+- Los vectores fastText preentrenados requieren citar la referencia oficial
+  indicada por fastText:
+  https://fasttext.cc/docs/en/pretrained-vectors#references
 - La lematización en castellano se mantiene deliberadamente ligera; no se añade
   una dependencia pesada de NLP para este caso de uso.
 - Se añade una llamada de warmup desde frontend al abrir el modal de alertas; es
@@ -123,17 +169,31 @@ Se añaden pruebas unitarias para:
 - Comportamiento sin resultados.
 - Warmup exitoso, idempotencia y manejo de fallo sin repetir inicialización
   costosa.
+- Uso de fastText cuando WordNet devuelve pocos resultados.
+- Funcionamiento sin fastText configurado.
+- Manejo de ruta de modelo inexistente.
+- Orden determinista: WordNet/OMW antes de fastText.
+- Filtrado, deduplicación, exclusión del término original y acrónimos con
+  capitalización variable.
 
 También se añade una prueba funcional del endpoint del backend y una prueba del
 servicio de frontend que consume la API, incluyendo el trigger de warmup.
+
+Las pruebas unitarias de fastText usan dobles de prueba y no descargan ni cargan
+vectores reales en CI.
 
 ## Implicaciones operativas
 
 La imagen Docker descarga `wordnet` y `omw-1.4` durante el build. La pipeline de
 CI instala los mismos corpus antes de ejecutar las pruebas que los necesitan.
 
+El paquete Python compatible con fastText se instala con las dependencias del
+backend, pero el fichero de vectores es opcional y externo. En producción puede
+apuntarse `NEWSRADAR_FASTTEXT_MODEL_PATH` a un modelo español preentrenado de
+fastText. Si falta, se registra un aviso y se continúa con WordNet/OMW.
+
 Si los corpus no están disponibles en runtime, el backend devuelve `503` para el
 endpoint de sinónimos en lugar de fallar con un error interno.
 
 El warmup se ejecuta exclusivamente en backend. El frontend solo dispara el
-endpoint de warmup y nunca carga NLTK localmente.
+endpoint de warmup y nunca carga NLTK ni fastText localmente.

--- a/docs/adr/0016-generacion-sinonimos-wordnet.md
+++ b/docs/adr/0016-generacion-sinonimos-wordnet.md
@@ -15,6 +15,9 @@ clave. Para reducir trabajo manual y mejorar la cobertura de búsquedas en
 castellano, se necesita generar sinónimos para un término base dentro del flujo
 normal de alta de alertas.
 
+Además, se observó latencia perceptible en la primera petición de sinónimos
+porque NLTK/OMW inicializa parte de los recursos de forma perezosa en memoria.
+
 La solución debía cumplir varias restricciones:
 
 - No depender de APIs externas, servicios alojados ni costes de uso.
@@ -32,6 +35,7 @@ Se decide implementar la generación de sinónimos en el backend mediante
 El backend expone un endpoint autenticado para el flujo de alertas:
 
 - `GET /api/v1/alerts/synonyms?term=<termino>&limit=<3-10>`
+- `GET /api/v1/alerts/synonyms/warmup`
 
 La lógica queda encapsulada en `app/core/synonyms.py` y aplica:
 
@@ -40,6 +44,8 @@ La lógica queda encapsulada en `app/core/synonyms.py` y aplica:
 - Variantes simples para plurales frecuentes en castellano.
 - Fallback léxico local para alias/acrónimos frecuentes (por ejemplo `ia`).
 - Descomposición de frases en tokens cuando no hay entrada directa útil.
+- Warmup idempotente en backend para precargar recursos NLTK/OMW mediante una
+  consulta inocua.
 - Limpieza, deduplicación y exclusión del término original.
 - Límite configurable dentro del rango soportado de 3 a 10 resultados.
 
@@ -55,6 +61,8 @@ La lógica queda encapsulada en `app/core/synonyms.py` y aplica:
   mediante `lang="spa"`, suficiente para el caso de uso de descriptores.
 - **Extensibilidad:** La separación en un módulo de core permite sustituir o
   enriquecer la fuente léxica más adelante sin cambiar el contrato del frontend.
+- **Mejor UX inicial:** El warmup reduce la latencia visible de la primera
+  generación de sinónimos sin bloquear el flujo de creación de alertas.
 
 ## Alternativas consideradas
 
@@ -101,6 +109,8 @@ léxicas estables.
   haber términos periodísticos, nombres propios o neologismos sin resultados.
 - La lematización en castellano se mantiene deliberadamente ligera; no se añade
   una dependencia pesada de NLP para este caso de uso.
+- Se añade una llamada de warmup desde frontend al abrir el modal de alertas; es
+  no bloqueante y se ejecuta una sola vez por sesión de pantalla.
 
 ## Implicaciones de testing
 
@@ -111,9 +121,11 @@ Se añaden pruebas unitarias para:
 - Exclusión del término original.
 - Manejo del límite de resultados.
 - Comportamiento sin resultados.
+- Warmup exitoso, idempotencia y manejo de fallo sin repetir inicialización
+  costosa.
 
 También se añade una prueba funcional del endpoint del backend y una prueba del
-servicio de frontend que consume la API.
+servicio de frontend que consume la API, incluyendo el trigger de warmup.
 
 ## Implicaciones operativas
 
@@ -122,3 +134,6 @@ CI instala los mismos corpus antes de ejecutar las pruebas que los necesitan.
 
 Si los corpus no están disponibles en runtime, el backend devuelve `503` para el
 endpoint de sinónimos en lugar de fallar con un error interno.
+
+El warmup se ejecuta exclusivamente en backend. El frontend solo dispara el
+endpoint de warmup y nunca carga NLTK localmente.

--- a/docs/ai/prompts/alert-synonym-generation-wordnet.md
+++ b/docs/ai/prompts/alert-synonym-generation-wordnet.md
@@ -1,0 +1,158 @@
+# Prompt: Alert Synonym Generation with Local Lexical Fallback
+
+- **Date:** 2026-04-27
+- **Tool:** Codex (gpt-5.5)
+- **Task:** Implement local synonym generation for alert descriptors and refine the selection UX
+
+---
+
+## Prompt Summary
+
+The session requested implementation of a local synonym-generation feature for
+the alert creation flow, followed by a second refinement pass focused on UX and
+lexical coverage.
+
+The implemented work covered:
+
+1. Backend synonym generation using NLTK WordNet and `omw-1.4`.
+2. Spanish as the primary supported language.
+3. Clean, deduplicated results with configurable limits and exclusion of the
+   original term.
+4. Frontend integration through the normal alert creation interface.
+5. ADR documentation for the decision and its operational implications.
+6. Automated backend and frontend tests.
+7. UX refinement so synonym generation no longer replaces user-entered
+   descriptors.
+8. Suggestion generation for every entered descriptor, not only the first.
+9. Clickable suggestion chips so the user can choose which synonyms to add.
+10. Hard enforcement of the 10-descriptor limit in the UI.
+11. A lightweight lexical fallback for terms such as `IA`, without introducing
+    a local LLM runtime.
+
+## Key Constraints from Prompt
+
+- Prefer a free, deterministic, lightweight local lexical approach over an LLM.
+- Do not use hosted APIs or paid services.
+- Do not introduce Ollama or another separate local AI server/process unless
+  absolutely necessary.
+- Keep the implementation native to the current FastAPI backend and React
+  frontend architecture.
+- Reuse existing conventions for API design, tests, CI, ADRs, and error
+  handling.
+- Add fallback behavior for unrecognized descriptors only if it remains
+  operationally lightweight.
+
+## Files Produced
+
+See `docs/ai/usage.md` for the traceability entry covering the backend synonym
+service, frontend alert UX changes, tests, and ADR update derived from this
+prompted work.
+
+## Full Prompt
+
+Implement a new synonym-generation functionality for this project with the following requirements and constraints.
+
+Context:
+
+* The project has a backend server, a PostgreSQL database, and a frontend application.
+* The backend and frontend are both written in Python.
+* We want a completely free solution with good Spanish support.
+* Do not use external hosted APIs or paid services.
+* Do not introduce Ollama or other separate local AI servers/processes unless absolutely necessary.
+* Prefer a lightweight local lexical approach over an LLM.
+
+Goal:
+
+* Add support for generating 3 to 10 synonyms for a given term, with Spanish as the primary supported language.
+* The solution should be deterministic, lightweight, and suitable for production use in our existing architecture.
+
+Implementation requirements:
+
+1. Use a local Python-based approach centered on:
+
+   * NLTK WordNet
+   * NLTK omw-1.4
+2. Use Spanish through Open Multilingual WordNet via NLTK.
+3. If appropriate, normalize or lemmatize the input term before lookup.
+4. Return clean, deduplicated synonyms.
+5. Exclude the original term from the final result set.
+6. Make the result limit configurable, but support the 3-10 range cleanly.
+7. Prefer a design where this functionality lives in the backend and is exposed to the frontend through the project’s normal interfaces.
+8. Avoid heavy dependencies unless they are clearly justified.
+9. If there is already an established service/module/controller pattern in the codebase, follow it exactly.
+10. Reuse existing coding conventions, typing style, logging style, configuration patterns, and error-handling patterns.
+
+Design expectations:
+
+* First inspect the repository structure and existing architecture before making changes.
+* Find the appropriate place to implement the feature rather than inventing a parallel pattern.
+* If there is already a text-processing, dictionary, search, or utilities area, consider integrating there.
+* If dependencies must be added, add only the minimum necessary ones.
+* Ensure the app behaves reasonably when no synonyms are found.
+* Ensure the functionality is easy to extend later.
+
+ADR requirement:
+
+* Create a new ADR in `./docs/adr/`.
+* Match the style, structure, naming convention, and tone of the existing ADRs exactly.
+* The ADR should explain:
+
+  * the problem,
+  * the chosen solution,
+  * alternatives considered,
+  * why a lightweight lexical solution was chosen over an LLM,
+  * operational implications,
+  * testing implications,
+  * any dependency/storage/runtime considerations.
+
+Testing requirement:
+
+* Add or update automated tests for this functionality.
+* Integrate them into the existing CI pipeline conventions already used by the repository.
+* Follow the existing testing style and folder structure.
+* Cover at least:
+
+  * basic Spanish synonym lookup,
+  * deduplication,
+  * exclusion of the original term,
+  * limit handling,
+  * no-results behavior,
+  * any API/service integration points introduced by your implementation.
+
+CI requirement:
+
+* Make sure the tests are included in the existing CI pipeline.
+* Do not invent a separate ad hoc test command if the repo already has a standard way to run tests.
+* If CI configuration updates are needed, make them in the style already used by the repository.
+
+Validation steps:
+
+* Inspect the codebase and determine the correct architectural integration points.
+* Implement the feature fully.
+* Run the relevant tests locally.
+* Run formatting/linting/type checks if those are part of the project workflow.
+* Confirm the new functionality is wired through appropriately end to end.
+
+Git requirement:
+
+* Commit the changes in sensible commits as you see fit.
+* Do not push anything to the GitHub repository.
+* Do not create a PR.
+* Do not modify remote settings.
+
+Output expectations:
+
+* After finishing, provide a concise summary of:
+
+  * what was changed,
+  * where it was changed,
+  * what ADR was added,
+  * what tests were added,
+  * which commands were run,
+  * any follow-up concerns or assumptions.
+
+Important:
+
+* Before coding, inspect the existing ADRs and mirror their style closely.
+* Before choosing file locations or patterns, inspect the current repository and follow its conventions.
+* Make the implementation feel native to the codebase rather than bolted on.

--- a/docs/ai/usage.md
+++ b/docs/ai/usage.md
@@ -46,6 +46,15 @@ This document records the use of AI-assisted tools in the development of NEWSRAD
 | Merge conflict resolution in backend and docs | opencode (mimo-v2-pro-free) | `docs/ai/prompts/merge-conflict-resolution.md` |
 | Backend structure reconciliation after merge | opencode (mimo-v2-pro-free) | `docs/ai/prompts/merge-conflict-resolution.md` |
 
+### Alert Synonym Generation (Sprint 4)
+
+| Artifact | AI Tool | Prompt Location |
+|---|---|---|
+| Backend synonym service with WordNet/OMW and lexical fallback | Codex (gpt-5) | `docs/ai/prompts/alert-synonym-generation-wordnet.md` |
+| Frontend alert descriptor synonym selection UX | Codex (gpt-5) | `docs/ai/prompts/alert-synonym-generation-wordnet.md` |
+| Backend and frontend automated tests for synonym generation | Codex (gpt-5) | `docs/ai/prompts/alert-synonym-generation-wordnet.md` |
+| ADR 0016 synonym-generation documentation update | Codex (gpt-5) | `docs/ai/prompts/alert-synonym-generation-wordnet.md` |
+
 ---
 
 ## Policy

--- a/scripts/download-fasttext-es.sh
+++ b/scripts/download-fasttext-es.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# scripts/download-fasttext-es.sh — Download Spanish fastText vectors for local development
+if [ -z "${BASH_VERSION:-}" ]; then
+    exec bash "$0" "$@"
+fi
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+MODEL_DIR="$ROOT_DIR/.models/fasttext"
+MODEL_GZ_PATH="$MODEL_DIR/cc.es.300.bin.gz"
+MODEL_PATH="$MODEL_DIR/cc.es.300.bin"
+MODEL_URL="https://dl.fbaipublicfiles.com/fasttext/vectors-crawl/cc.es.300.bin.gz"
+FORCE=false
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_info()  { echo -e "${GREEN}[INFO]${NC} $*"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
+
+show_help() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Download the Spanish fastText binary vectors used by the optional synonym fallback.
+
+OPTIONS:
+    --force      Re-download and overwrite the local model
+    -h, --help   Show this help message
+
+OUTPUT:
+    $MODEL_PATH
+
+EXAMPLES:
+    $(basename "$0")
+    $(basename "$0") --force
+
+EOF
+}
+
+download_file() {
+    if command -v curl &>/dev/null; then
+        curl -L --fail --progress-bar "$MODEL_URL" -o "$MODEL_GZ_PATH"
+    elif command -v wget &>/dev/null; then
+        wget -O "$MODEL_GZ_PATH" "$MODEL_URL"
+    else
+        log_error "curl or wget is required to download fastText vectors"
+        exit 1
+    fi
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --force)
+            FORCE=true
+            shift
+            ;;
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        *)
+            log_error "Unknown option: $1"
+            show_help
+            exit 1
+            ;;
+    esac
+done
+
+mkdir -p "$MODEL_DIR"
+
+if [[ -f "$MODEL_PATH" && "$FORCE" != true ]]; then
+    log_info "Spanish fastText model already exists: $MODEL_PATH"
+    log_info "Use --force to re-download it."
+    exit 0
+fi
+
+log_warn "This downloads the Spanish fastText binary model. It is large and remains untracked."
+log_info "Source: $MODEL_URL"
+
+rm -f "$MODEL_GZ_PATH"
+download_file
+
+log_info "Decompressing model..."
+gzip -dc "$MODEL_GZ_PATH" > "$MODEL_PATH"
+rm -f "$MODEL_GZ_PATH"
+
+log_info "Spanish fastText model ready: $MODEL_PATH"
+log_info "Start dev with: scripts/start-dev.sh --both-parallel --fasttext"

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -49,9 +49,9 @@ OPTIONS:
     --frontend        Start only the frontend in foreground
     --both            Start both services in background
     --both-parallel   Start both services in foreground with interleaved output
-    --fasttext        Enable local fastText suggestions using .models/fasttext/cc.es.300.bin
+    --fasttext        Enable experimental local fastText suggestions using .models/fasttext/cc.es.300.bin
     --fasttext-model PATH
-                      Enable local fastText suggestions using a custom .bin model path
+                      Enable experimental local fastText suggestions using a custom .bin model path
     -h, --help        Show this help message
 
 EXAMPLES:

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 # scripts/start-dev.sh — Start the development environment
+if [ -z "${BASH_VERSION:-}" ]; then
+    exec bash "$0" "$@"
+fi
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -8,6 +11,7 @@ BACKEND_DIR="$ROOT_DIR/Backend"
 FRONTEND_DIR="$ROOT_DIR/Frontend"
 VENV_PYTHON="$ROOT_DIR/.venv/bin/python"
 VENV_PIP="$ROOT_DIR/.venv/bin/pip"
+DEFAULT_FASTTEXT_MODEL_PATH="$ROOT_DIR/.models/fasttext/cc.es.300.bin"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -45,6 +49,9 @@ OPTIONS:
     --frontend        Start only the frontend in foreground
     --both            Start both services in background
     --both-parallel   Start both services in foreground with interleaved output
+    --fasttext        Enable local fastText suggestions using .models/fasttext/cc.es.300.bin
+    --fasttext-model PATH
+                      Enable local fastText suggestions using a custom .bin model path
     -h, --help        Show this help message
 
 EXAMPLES:
@@ -52,6 +59,8 @@ EXAMPLES:
     $(basename "$0") --frontend        # Start only frontend
     $(basename "$0") --both            # Start both in background
     $(basename "$0") --both-parallel   # Start both in foreground
+    $(basename "$0") --both-parallel --fasttext
+    $(basename "$0") --backend --fasttext-model /path/to/cc.es.300.bin
 
 EOF
 }
@@ -137,10 +146,28 @@ run_migrations() {
     cd "$ROOT_DIR"
 }
 
+configure_fasttext() {
+    FASTTEXT_ENV_ARGS=()
+
+    if [[ -z "${FASTTEXT_MODEL_PATH:-}" ]]; then
+        return
+    fi
+
+    if [[ ! -f "$FASTTEXT_MODEL_PATH" ]]; then
+        log_warn "fastText model not found at $FASTTEXT_MODEL_PATH"
+        log_warn "Run: scripts/download-fasttext-es.sh"
+        log_warn "Starting backend without fastText fallback."
+        return
+    fi
+
+    FASTTEXT_ENV_ARGS=("NEWSRADAR_FASTTEXT_MODEL_PATH=$FASTTEXT_MODEL_PATH")
+    log_info "Using fastText Spanish model: $FASTTEXT_MODEL_PATH"
+}
+
 start_backend() {
     log_info "Starting backend..."
     cd "$BACKEND_DIR"
-    NEWSRADAR_CONFIGURE_LOCAL_ELASTICSEARCH=true "$VENV_PYTHON" -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000 &
+    env NEWSRADAR_CONFIGURE_LOCAL_ELASTICSEARCH=true "${FASTTEXT_ENV_ARGS[@]}" "$VENV_PYTHON" -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000 &
     BACKEND_PID=$!
     cd "$ROOT_DIR"
     log_info "Backend started on http://localhost:8000"
@@ -149,7 +176,7 @@ start_backend() {
 start_backend_blocking() {
     log_info "Starting backend (blocking)..."
     cd "$BACKEND_DIR"
-    exec env NEWSRADAR_CONFIGURE_LOCAL_ELASTICSEARCH=true "$VENV_PYTHON" -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+    exec env NEWSRADAR_CONFIGURE_LOCAL_ELASTICSEARCH=true "${FASTTEXT_ENV_ARGS[@]}" "$VENV_PYTHON" -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
 }
 
 start_frontend() {
@@ -179,6 +206,7 @@ wait_for_services() {
 }
 
 MODE=""
+FASTTEXT_MODEL_PATH="${NEWSRADAR_FASTTEXT_MODEL_PATH:-}"
 while [[ $# -gt 0 ]]; do
     case $1 in
         --backend)
@@ -196,6 +224,19 @@ while [[ $# -gt 0 ]]; do
         --both-parallel)
             MODE="both-parallel"
             shift
+            ;;
+        --fasttext)
+            FASTTEXT_MODEL_PATH="$DEFAULT_FASTTEXT_MODEL_PATH"
+            shift
+            ;;
+        --fasttext-model)
+            if [[ -z "${2:-}" ]]; then
+                log_error "--fasttext-model requires a path"
+                show_help
+                exit 1
+            fi
+            FASTTEXT_MODEL_PATH="$2"
+            shift 2
             ;;
         -h|--help)
             show_help
@@ -220,6 +261,7 @@ case "$MODE" in
         install_backend_deps
         start_databases
         run_migrations
+        configure_fasttext
         start_backend_blocking
         ;;
     frontend)
@@ -232,6 +274,7 @@ case "$MODE" in
         install_frontend_deps
         start_databases
         run_migrations
+        configure_fasttext
         start_backend
         sleep 2
         start_frontend
@@ -244,10 +287,11 @@ case "$MODE" in
         install_frontend_deps
         start_databases
         run_migrations
+        configure_fasttext
         log_info "Starting both services in parallel..."
 
         cd "$BACKEND_DIR"
-        "$VENV_PYTHON" -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000 &
+        env NEWSRADAR_CONFIGURE_LOCAL_ELASTICSEARCH=true "${FASTTEXT_ENV_ARGS[@]}" "$VENV_PYTHON" -m uvicorn app.main:app --reload --host 0.0.0.0 --port 8000 &
         BACKEND_PID=$!
         cd "$ROOT_DIR"
 


### PR DESCRIPTION
## Summary
- add local Spanish synonym generation for alert descriptors using NLTK WordNet/OMW
- improve alert creation UX so synonym suggestions are generated per descriptor and appended by user selection
- add deterministic lexical fallback for terms like `IA` and update ADR 0016

## Testing
- bash scripts/check.sh
- cd Backend && ../.venv/bin/python -m pytest tests/functional/test_synonyms.py -v --tb=short -m integration
- cd Frontend && npm run test:run
- cd Frontend && npm run build