### PR TITLE
ci: add tag-driven release workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,8 @@ name: CD
 
 on:
   push:
-    branches: [main]
+    tags:
+      - "v*.*.*"
   workflow_dispatch:
 
 env:
@@ -10,17 +11,22 @@ env:
   IMAGE_NAME: ${{ github.repository }}/backend
 
 jobs:
-  # ──────────────────────────────────────────────
-  #  Build and push Docker image
-  # ──────────────────────────────────────────────
   build-and-push:
-    name: Build & Push Image
+    name: Build, Push, and Release
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
     steps:
       - uses: actions/checkout@v4
+
+      - name: Validate release tag
+        run: |
+          if [[ ! "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid release tag: ${GITHUB_REF_NAME}"
+            echo "Expected format: vMAJOR.MINOR.PATCH"
+            exit 1
+          fi
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -35,9 +41,12 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=sha
-            type=ref,event=branch
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -47,19 +56,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-  # ──────────────────────────────────────────────
-  #  Deploy (placeholder — adapt to your infra)
-  # ──────────────────────────────────────────────
-  deploy:
-    name: Deploy
-    needs: [build-and-push]
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
-    environment: production
-    steps:
-      - name: Deploy placeholder
-        run: |
-          echo "TODO: Add deployment steps here"
-          echo "Image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"
-          echo "Options: docker-compose pull && docker-compose up -d"
-          echo "         or: ssh into server and pull new image"
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          generate_release_notes: true

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,111 @@
+name: Release Tag Automation
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  create-release-tag:
+    name: Create Release Tag
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Decide release bump from PR labels
+        id: decide
+        run: |
+          LABELS="$(jq -r '.pull_request.labels[].name' "$GITHUB_EVENT_PATH")"
+          echo "PR labels:"
+          echo "${LABELS}"
+
+          BUMP_LABELS="$(echo "${LABELS}" | grep -E '^release:(patch|minor|major)$' || true)"
+          BUMP_COUNT="$(echo "${BUMP_LABELS}" | sed '/^$/d' | wc -l | tr -d ' ')"
+
+          if [[ "${BUMP_COUNT}" -gt 1 ]]; then
+            echo "More than one release label found:"
+            echo "${BUMP_LABELS}"
+            exit 1
+          fi
+
+          if [[ "${BUMP_COUNT}" -eq 0 ]]; then
+            echo "should_tag=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if echo "${LABELS}" | grep -q '^no-release$'; then
+            echo "Label conflict: no-release with release:*."
+            exit 1
+          fi
+
+          BUMP="${BUMP_LABELS#release:}"
+          echo "should_tag=true" >> "$GITHUB_OUTPUT"
+          echo "bump=${BUMP}" >> "$GITHUB_OUTPUT"
+
+      - name: Compute next semantic tag
+        id: next
+        if: steps.decide.outputs.should_tag == 'true'
+        run: |
+          git fetch --tags --force
+          LATEST_TAG="$(git tag -l 'v*.*.*' --sort=-version:refname | head -n 1)"
+
+          if [[ -z "${LATEST_TAG}" ]]; then
+            MAJOR=0
+            MINOR=0
+            PATCH=0
+          elif [[ "${LATEST_TAG}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            MAJOR="${BASH_REMATCH[1]}"
+            MINOR="${BASH_REMATCH[2]}"
+            PATCH="${BASH_REMATCH[3]}"
+          else
+            echo "Latest tag has invalid format: ${LATEST_TAG}"
+            exit 1
+          fi
+
+          BUMP="${{ steps.decide.outputs.bump }}"
+          if [[ "${BUMP}" == "major" ]]; then
+            MAJOR=$((MAJOR + 1))
+            MINOR=0
+            PATCH=0
+          elif [[ "${BUMP}" == "minor" ]]; then
+            MINOR=$((MINOR + 1))
+            PATCH=0
+          elif [[ "${BUMP}" == "patch" ]]; then
+            PATCH=$((PATCH + 1))
+          else
+            echo "Unsupported bump type: ${BUMP}"
+            exit 1
+          fi
+
+          NEXT_TAG="v${MAJOR}.${MINOR}.${PATCH}"
+          echo "next_tag=${NEXT_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Next release tag: ${NEXT_TAG}"
+
+      - name: Create and push tag
+        if: steps.decide.outputs.should_tag == 'true'
+        env:
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          NEXT_TAG: ${{ steps.next.outputs.next_tag }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [[ -z "${MERGE_SHA}" ]]; then
+            echo "Missing merge commit SHA from pull_request event."
+            exit 1
+          fi
+
+          if git rev-parse "${NEXT_TAG}" >/dev/null 2>&1; then
+            echo "Tag already exists: ${NEXT_TAG}"
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${NEXT_TAG}" "${MERGE_SHA}" -m "Release ${NEXT_TAG} from PR #${PR_NUMBER}"
+          git push origin "${NEXT_TAG}"

--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "bootstrap": "^5.3.8",
+        "d3-cloud": "^1.2.9",
         "i18next": "^26.0.8",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -1186,6 +1187,17 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.11.2",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
@@ -1846,6 +1858,27 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -1911,6 +1944,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2011,7 +2052,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2195,6 +2236,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -2546,7 +2598,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -2561,6 +2613,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-cloud": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/d3-cloud/-/d3-cloud-1.2.9.tgz",
+      "integrity": "sha512-leL1GLneC9ZQtnV+6TGWrNlGfI1WX7S2arcTv2vae12DaXo5wjm6GBCkskXbrDlyOymd/A75Pyj1H37MW4BZ/Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-dispatch": "^1.0.3"
+      }
+    },
     "node_modules/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
@@ -2569,6 +2630,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
+      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/d3-ease": {
       "version": "3.0.1",
@@ -2761,6 +2828,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4054,6 +4129,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4339,6 +4425,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4396,6 +4512,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-redux": {
       "version": "9.2.0",

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "bootstrap": "^5.3.8",
+    "d3-cloud": "^1.2.9",
     "i18next": "^26.0.8",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ pre-commit install
 
 ## CI/CD
 
-GitHub Actions runs on every push to `main` and on pull requests:
+GitHub Actions CI runs on every push to `main` and on pull requests:
 
 - **Backend:** Ruff lint, Ty type check, pytest unit + integration tests
 - **Frontend:** Vitest tests, build check
@@ -111,6 +111,14 @@ GitHub Actions runs on every push to `main` and on pull requests:
 - **Security:** pip-audit, npm audit, Trivy container scan
 - **Quality:** SonarQube analysis
 - **Docs:** MkDocs build (PR) + deploy a GitHub Pages (main)
+
+CD releases are tag-driven:
+- Manual release: `git tag vX.Y.Z && git push origin vX.Y.Z`
+- Automatic release tag on merged PR to `main` when PR has exactly one label:
+  - `release:patch`
+  - `release:minor`
+  - `release:major`
+- PRs without release label do not create a version tag.
 
 See [docs/deployment/cicd.md](docs/deployment/cicd.md) for full pipeline details.
 

--- a/docs/adr/0011-pipeline-cicd-github-actions.md
+++ b/docs/adr/0011-pipeline-cicd-github-actions.md
@@ -27,7 +27,9 @@ Se implementa un pipeline de CI/CD con **GitHub Actions** compuesto por:
 
 - **ci.yml:** verificación completa en cada push y pull request.
 - **cd.yml:** construcción y publicación de imágenes Docker en el registro
-  de contenedores de GitHub (GHCR).
+  de contenedores de GitHub (GHCR), activado por tags de versión.
+- **release-tag.yml:** creación automática de tags semánticos al mergear PRs
+  etiquetadas para release (`release:patch|minor|major`).
 
 ## Justificación
 
@@ -56,10 +58,14 @@ Se implementa un pipeline de CI/CD con **GitHub Actions** compuesto por:
 9. **sonarqube** — análisis de calidad SonarQube
 10. **trivy-scan** — escaneo de vulnerabilidades de contenedor
 
-### cd.yml (2 jobs)
+### cd.yml (1 job)
 
 1. **build-and-push** — build y push a GHCR
-2. **deploy** — placeholder para despliegue
+
+### release-tag.yml (1 job)
+
+1. **create-release-tag** — calcula siguiente versión semántica y crea tag
+   al mergear PR con etiqueta de release
 
 ## Consecuencias
 
@@ -67,7 +73,8 @@ Se implementa un pipeline de CI/CD con **GitHub Actions** compuesto por:
 
 - Feedback rápido en PRs: lint, typecheck y tests unitarios en minutos.
 - Validación completa antes de merge: integración, E2E, seguridad.
-- Imágenes Docker publicadas automáticamente en cada push a main.
+- Releases Docker se publican cuando existe decisión explícita de versión
+  (tag manual o etiqueta de release en PR).
 - Service containers eliminan la complejidad de docker-compose en CI.
 - Caché de dependencias reduce tiempos de ejecución.
 
@@ -93,4 +100,5 @@ Se implementa un pipeline de CI/CD con **GitHub Actions** compuesto por:
 ## Configuración aplicada
 
 - `.github/workflows/ci.yml` — pipeline completo de CI
-- `.github/workflows/cd.yml` — pipeline de despliegue (stub)
+- `.github/workflows/cd.yml` — pipeline de release por tags semánticos
+- `.github/workflows/release-tag.yml` — automatización de versionado por etiquetas de PR

--- a/docs/deployment/cicd.md
+++ b/docs/deployment/cicd.md
@@ -7,7 +7,9 @@
 
 ## Overview
 
-NEWSRADAR uses **GitHub Actions** for CI/CD. The pipeline runs on every push to `main` and on pull requests.
+NEWSRADAR uses **GitHub Actions** for CI/CD.
+- CI pipeline runs on every push to `main` and on pull requests.
+- CD release pipeline runs on semantic version tags (`vMAJOR.MINOR.PATCH`) plus manual dispatch reruns.
 
 ### Pipeline stages
 
@@ -74,14 +76,27 @@ push/PR → ┌──────────────┐
 
 ### cd.yml — Continuous Deployment
 
-**Triggers:** push to `main`, manual dispatch
+**Triggers:** push tags `v*.*.*`, manual dispatch
 
 **Jobs:**
 
 | Job | What it does |
 |---|---|
-| `build-and-push` | Build and push Docker image to GHCR |
-| `deploy` | Placeholder for deployment steps |
+| `build-and-push` | Validate tag format, build and push backend Docker image to GHCR, create GitHub Release |
+
+### release-tag.yml — Automatic release tagging
+
+**Triggers:** pull request closed on `main` (merged only)
+
+**Behavior:**
+- Reads PR labels and accepts exactly one of:
+  - `release:patch`
+  - `release:minor`
+  - `release:major`
+- Computes next semantic version from latest existing `v*.*.*` tag.
+- Creates and pushes new release tag on merge commit.
+- If no release label is present, no tag is created.
+- Manual tags are always supported and use same CD workflow.
 
 ### docs.yml — Documentation pipeline
 


### PR DESCRIPTION
## Summary
- Add tag-driven CD workflow for semantic version tags (`vMAJOR.MINOR.PATCH`) that builds/pushes backend image to GHCR and creates GitHub releases.
- Add automatic release-tag workflow for merged PRs labeled `release:patch`, `release:minor`, or `release:major`.
- Update README, deployment docs, and CI/CD ADR with release behavior.
- Fix frontend CI by declaring missing `d3-cloud` dependency and regenerating npm 10 lockfile.

## Verification
- `cd Frontend && npm ci`
- `cd Frontend && npm run test:run`
- `cd Frontend && npm run build`
- `git diff --check -- .github/workflows/cd.yml .github/workflows/release-tag.yml README.md docs/adr/0011-pipeline-cicd-github-actions.md docs/deployment/cicd.md`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/cd.yml .github/workflows/release-tag.yml`

## Notes
- `actionlint` is not installed locally, so workflow validation was limited to YAML parsing and whitespace checks.
- Frontend build passes with existing Vite chunk-size warning.
- `npm ci` reports existing audit findings: 2 moderate, 1 high.